### PR TITLE
Set RequireExpirationTime to false to fix the "The token has no expiration" error

### DIFF
--- a/Nop.Plugin.Api/ApiAuthentication.cs
+++ b/Nop.Plugin.Api/ApiAuthentication.cs
@@ -23,6 +23,7 @@
                     jwt.Audience = "nop_api";
                     jwt.TokenValidationParameters = new TokenValidationParameters
                     {
+						RequireExpirationTime = false,
                         ValidateActor = false,
                         ValidateIssuer = false,
                         NameClaimType = JwtClaimTypes.Name,

--- a/Nop.Plugin.Api/ApiAuthentication.cs
+++ b/Nop.Plugin.Api/ApiAuthentication.cs
@@ -23,7 +23,7 @@
                     jwt.Audience = "nop_api";
                     jwt.TokenValidationParameters = new TokenValidationParameters
                     {
-						RequireExpirationTime = false,
+                        RequireExpirationTime = false,
                         ValidateActor = false,
                         ValidateIssuer = false,
                         NameClaimType = JwtClaimTypes.Name,


### PR DESCRIPTION
I've tested the api plugin using the sample application and a fresh install of nopcommerce 4.0. and I get the following error when clicking on the "Get Customers" Iink.

`WWW-Authenticate →Bearer error="invalid_token", error_description="The token has no expiration"`

Setting the **RequireExpirationTime** property to **false** fixes this issue.