### PR TITLE
Implement SpecificationAttribute/ProductSpecificationAttribute

### DIFF
--- a/Nop.Plugin.Api/ApiMapperConfiguration.cs
+++ b/Nop.Plugin.Api/ApiMapperConfiguration.cs
@@ -26,6 +26,7 @@
     using Nop.Plugin.Api.DTOs.ProductAttributes;
     using Nop.Plugin.Api.DTOs.ProductCategoryMappings;
     using Nop.Plugin.Api.DTOs.Products;
+    using Nop.Plugin.Api.DTOs.SpecificationAttributes;
     using Nop.Plugin.Api.DTOs.ShoppingCarts;
     using Nop.Plugin.Api.DTOs.Stores;
     using Nop.Plugin.Api.MappingExtensions;
@@ -68,6 +69,11 @@
             CreateMap<ProductAttributeValue, ProductAttributeValueDto>();
 
             CreateMap<ProductAttribute, ProductAttributeDto>();
+
+            CreateMap<ProductSpecificationAttribute, ProductSpecificationAttributeDto>();
+
+            CreateMap<SpecificationAttribute, SpecificationAttributeDto>();
+            CreateMap<SpecificationAttributeOption, SpecificationAttributeOptionDto>();
 
             CreateMap<NewsLetterSubscriptionDto, NewsLetterSubscription>();
             CreateMap<NewsLetterSubscription, NewsLetterSubscriptionDto>();
@@ -170,6 +176,7 @@
             AutoMapperApiConfiguration.MapperConfigurationExpression.CreateMap<Product, ProductDto>()
                .IgnoreAllNonExisting()
                .ForMember(x => x.ProductAttributeMappings, y => y.Ignore())
+               .ForMember(x => x.ProductSpecificationAttributes, y => y.Ignore())
                .ForMember(x => x.FullDescription, y => y.MapFrom(src => WebUtility.HtmlEncode(src.FullDescription)))
                .ForMember(x => x.Tags, y => y.MapFrom(src => src.ProductTags.Select(x => x.Name)));
         }

--- a/Nop.Plugin.Api/Controllers/ProductSpecificationAttributesController.cs
+++ b/Nop.Plugin.Api/Controllers/ProductSpecificationAttributesController.cs
@@ -1,0 +1,257 @@
+﻿using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.AspNetCore.Mvc;
+using Nop.Core.Domain.Catalog;
+using Nop.Plugin.Api.Attributes;
+using Nop.Plugin.Api.Constants;
+using Nop.Plugin.Api.Delta;
+using Nop.Plugin.Api.DTOs.Errors;
+using Nop.Plugin.Api.DTOs.SpecificationAttributes;
+using Nop.Plugin.Api.Helpers;
+using Nop.Plugin.Api.JSON.ActionResults;
+using Nop.Plugin.Api.JSON.Serializers;
+using Nop.Plugin.Api.ModelBinders;
+using Nop.Plugin.Api.Models.ProductSpecificationAttributes;
+using Nop.Plugin.Api.Services;
+using Nop.Services.Catalog;
+using Nop.Services.Customers;
+using Nop.Services.Discounts;
+using Nop.Services.Localization;
+using Nop.Services.Logging;
+using Nop.Services.Media;
+using Nop.Services.Security;
+using Nop.Services.Stores;
+using System;
+using System.Linq;
+using System.Net;
+
+namespace Nop.Plugin.Api.Controllers
+{
+    [ApiAuthorize(Policy = JwtBearerDefaults.AuthenticationScheme, AuthenticationSchemes = JwtBearerDefaults.AuthenticationScheme)]
+    public class ProductSpecificationAttributesController : BaseApiController
+    {
+        private readonly ISpecificationAttributeService _specificationAttributeService;
+        private readonly ISpecificationAttributeApiService _specificationAttributeApiService;
+        private readonly IDTOHelper _dtoHelper;
+
+        public ProductSpecificationAttributesController(IJsonFieldsSerializer jsonFieldsSerializer, 
+                                  ICustomerActivityService customerActivityService,
+                                  ILocalizationService localizationService,
+                                  IAclService aclService,
+                                  IStoreMappingService storeMappingService,
+                                  IStoreService storeService,
+                                  ICustomerService customerService,
+                                  IDiscountService discountService,
+                                  IPictureService pictureService,
+                                  ISpecificationAttributeService specificationAttributeService,
+                                  ISpecificationAttributeApiService specificationAttributesApiService,
+                                  IDTOHelper dtoHelper) : base(jsonFieldsSerializer, aclService, customerService, storeMappingService, storeService, discountService, customerActivityService, localizationService, pictureService)
+        {
+            _specificationAttributeService = specificationAttributeService;
+            _specificationAttributeApiService = specificationAttributesApiService;
+            _dtoHelper = dtoHelper;
+        }
+
+        /// <summary>
+        /// Receive a list of all product specification attributes
+        /// </summary>
+        /// <response code="200">OK</response>
+        /// <response code="400">Bad Request</response>
+        /// <response code="401">Unauthorized</response>
+        [HttpGet]
+        [Route("/api/productspecificationattributes")]
+        [ProducesResponseType(typeof(ProductSpecificationAttributesRootObjectDto), (int)HttpStatusCode.OK)]
+        [ProducesResponseType(typeof(ErrorsRootObject), (int)HttpStatusCode.BadRequest)]
+        [ProducesResponseType(typeof(string), (int)HttpStatusCode.Unauthorized)]
+        [GetRequestsErrorInterceptorActionFilter]
+        public IActionResult GetProductSpecificationAttributes(ProductSpecifcationAttributesParametersModel parameters)
+        {
+            if (parameters.Limit < Configurations.MinLimit || parameters.Limit > Configurations.MaxLimit)
+            {
+                return Error(HttpStatusCode.BadRequest, "limit", "invalid limit parameter");
+            }
+
+            if (parameters.Page < Configurations.DefaultPageValue)
+            {
+                return Error(HttpStatusCode.BadRequest, "page", "invalid page parameter");
+            }
+
+            var productSpecificationAttribtues = _specificationAttributeApiService.GetProductSpecificationAttributes(productId: parameters.ProductId, specificationAttributeOptionId: parameters.SpecificationAttributeOptionId, allowFiltering: parameters.AllowFiltering, showOnProductPage: parameters.ShowOnProductPage, limit: parameters.Limit, page: parameters.Page, sinceId: parameters.SinceId);
+
+            var productSpecificationAttributeDtos = productSpecificationAttribtues.Select(x => _dtoHelper.PrepareProductSpecificationAttributeDto(x)).ToList();
+
+            var productSpecificationAttributesRootObject = new ProductSpecificationAttributesRootObjectDto()
+            {
+                ProductSpecificationAttributes = productSpecificationAttributeDtos
+            };
+
+            var json = _jsonFieldsSerializer.Serialize(productSpecificationAttributesRootObject, parameters.Fields);
+
+            return new RawJsonActionResult(json);
+        }
+
+        /// <summary>
+        /// Receive a count of all product specification attributes
+        /// </summary>
+        /// <response code="200">OK</response>
+        /// <response code="401">Unauthorized</response>
+        [HttpGet]
+        [Route("/api/productspecificationattributes/count")]
+        [ProducesResponseType(typeof(ProductSpecificationAttributesCountRootObject), (int)HttpStatusCode.OK)]        
+        [ProducesResponseType(typeof(string), (int)HttpStatusCode.Unauthorized)]
+        [ProducesResponseType(typeof(ErrorsRootObject), (int)HttpStatusCode.BadRequest)]
+        [GetRequestsErrorInterceptorActionFilter]
+        public IActionResult GetProductSpecificationAttributesCount(ProductSpecifcationAttributesCountParametersModel parameters)
+        {
+            var productSpecificationAttributesCount = _specificationAttributeService.GetProductSpecificationAttributeCount(productId: parameters.ProductId, specificationAttributeOptionId: parameters.SpecificationAttributeOptionId);
+
+            var productSpecificationAttributesCountRootObject = new ProductSpecificationAttributesCountRootObject()
+            {
+                Count = productSpecificationAttributesCount
+            };
+
+            return Ok(productSpecificationAttributesCountRootObject);
+        }
+
+        /// <summary>
+        /// Retrieve product specification attribute by spcified id
+        /// </summary>
+        /// <param name="id">Id of the product specification  attribute</param>
+        /// <param name="fields">Fields from the product specification attribute you want your json to contain</param>
+        /// <response code="200">OK</response>
+        /// <response code="404">Not Found</response>
+        /// <response code="401">Unauthorized</response>
+        [HttpGet]
+        [Route("/api/productspecificationattributes/{id}")]
+        [ProducesResponseType(typeof(ProductSpecificationAttributesRootObjectDto), (int)HttpStatusCode.OK)]
+        [ProducesResponseType(typeof(string), (int)HttpStatusCode.Unauthorized)]
+        [ProducesResponseType(typeof(ErrorsRootObject), (int)HttpStatusCode.BadRequest)]
+        [ProducesResponseType(typeof(string), (int)HttpStatusCode.NotFound)]
+        [GetRequestsErrorInterceptorActionFilter]
+        public IActionResult GetProductSpecificationAttributeById(int id, string fields = "")
+        {
+            if (id <= 0)
+            {
+                return Error(HttpStatusCode.BadRequest, "id", "invalid id");
+            }
+
+            var productSpecificationAttribute = _specificationAttributeService.GetProductSpecificationAttributeById(id);
+
+            if (productSpecificationAttribute == null)
+            {
+                return Error(HttpStatusCode.NotFound, "product specification attribute", "not found");
+            }
+
+            var productSpecificationAttributeDto = _dtoHelper.PrepareProductSpecificationAttributeDto(productSpecificationAttribute);
+
+            var productSpecificationAttributesRootObject = new ProductSpecificationAttributesRootObjectDto();
+            productSpecificationAttributesRootObject.ProductSpecificationAttributes.Add(productSpecificationAttributeDto);
+
+            var json = _jsonFieldsSerializer.Serialize(productSpecificationAttributesRootObject, fields);
+
+            return new RawJsonActionResult(json);
+        }
+
+        [HttpPost]
+        [Route("/api/productspecificationattributes")]
+        [ProducesResponseType(typeof(ProductSpecificationAttributesRootObjectDto), (int)HttpStatusCode.OK)]
+        [ProducesResponseType(typeof(string), (int)HttpStatusCode.Unauthorized)]
+        [ProducesResponseType(typeof(ErrorsRootObject), (int)HttpStatusCode.BadRequest)]
+        [ProducesResponseType(typeof(string), (int)HttpStatusCode.NotFound)]
+        [ProducesResponseType(typeof(ErrorsRootObject), 422)]
+        public IActionResult CreateProductSpecificationAttribute([ModelBinder(typeof(JsonModelBinder<ProductSpecificationAttributeDto>))] Delta<ProductSpecificationAttributeDto> productSpecificaitonAttributeDelta)
+        {
+            // Here we display the errors if the validation has failed at some point.
+            if (!ModelState.IsValid)
+            {
+                return Error();
+            }
+
+            // Inserting the new product
+            var productSpecificationAttribute = new ProductSpecificationAttribute();
+            productSpecificaitonAttributeDelta.Merge(productSpecificationAttribute);
+
+            _specificationAttributeService.InsertProductSpecificationAttribute(productSpecificationAttribute);
+
+            _customerActivityService.InsertActivity("AddNewProductSpecificationAttribute", productSpecificationAttribute.Id.ToString());
+
+            // Preparing the result dto of the new product
+            var productSpecificationAttributeDto = _dtoHelper.PrepareProductSpecificationAttributeDto(productSpecificationAttribute);
+
+            var productSpecificationAttributesRootObjectDto = new ProductSpecificationAttributesRootObjectDto();
+            productSpecificationAttributesRootObjectDto.ProductSpecificationAttributes.Add(productSpecificationAttributeDto);
+
+            var json = _jsonFieldsSerializer.Serialize(productSpecificationAttributesRootObjectDto, string.Empty);
+
+            return new RawJsonActionResult(json);
+        }
+
+        [HttpPut]
+        [Route("/api/productspecificationattributes/{id}")]
+        [ProducesResponseType(typeof(ProductSpecificationAttributesRootObjectDto), (int)HttpStatusCode.OK)]
+        [ProducesResponseType(typeof(string), (int)HttpStatusCode.Unauthorized)]
+        [ProducesResponseType(typeof(ErrorsRootObject), (int)HttpStatusCode.BadRequest)]
+        [ProducesResponseType(typeof(string), (int)HttpStatusCode.NotFound)]
+        [ProducesResponseType(typeof(ErrorsRootObject), 422)]
+        public IActionResult UpdateProductSpecificationAttribute([ModelBinder(typeof(JsonModelBinder<ProductSpecificationAttributeDto>))] Delta<ProductSpecificationAttributeDto> productSpecificationAttributeDelta)
+        {
+            // Here we display the errors if the validation has failed at some point.
+            if (!ModelState.IsValid)
+            {
+                return Error();
+            }
+
+            // We do not need to validate the product attribute id, because this will happen in the model binder using the dto validator.
+            int productSpecificationAttributeId = productSpecificationAttributeDelta.Dto.Id;
+
+            var productSpecificationAttribute = _specificationAttributeService.GetProductSpecificationAttributeById(productSpecificationAttributeId);
+            if (productSpecificationAttribute == null)
+            {
+                return Error(HttpStatusCode.NotFound, "product specification attribute", "not found");
+            }
+
+            productSpecificationAttributeDelta.Merge(productSpecificationAttribute);
+
+            _specificationAttributeService.UpdateProductSpecificationAttribute(productSpecificationAttribute);
+          
+            _customerActivityService.InsertActivity("EditProductSpecificationAttribute", productSpecificationAttribute.Id.ToString());
+
+            // Preparing the result dto of the new product attribute
+            var productSpecificationAttributeDto = _dtoHelper.PrepareProductSpecificationAttributeDto(productSpecificationAttribute);
+
+            var productSpecificatoinAttributesRootObjectDto = new ProductSpecificationAttributesRootObjectDto();
+            productSpecificatoinAttributesRootObjectDto.ProductSpecificationAttributes.Add(productSpecificationAttributeDto);
+
+            var json = _jsonFieldsSerializer.Serialize(productSpecificatoinAttributesRootObjectDto, string.Empty);
+
+            return new RawJsonActionResult(json);
+        }
+
+        [HttpDelete]
+        [Route("/api/productspecificationattributes/{id}")]
+        [ProducesResponseType(typeof(void), (int)HttpStatusCode.OK)]
+        [ProducesResponseType(typeof(string), (int)HttpStatusCode.Unauthorized)]
+        [ProducesResponseType(typeof(ErrorsRootObject), (int)HttpStatusCode.BadRequest)]
+        [ProducesResponseType(typeof(string), (int)HttpStatusCode.NotFound)]
+        [ProducesResponseType(typeof(ErrorsRootObject), 422)]
+        public IActionResult DeleteProductSpecificationAttribute(int id)
+        {
+            if (id <= 0)
+            {
+                return Error(HttpStatusCode.BadRequest, "id", "invalid id");
+            }
+
+            var productSpecificationAttribute = _specificationAttributeService.GetProductSpecificationAttributeById(id);
+            if (productSpecificationAttribute == null)
+            {
+                return Error(HttpStatusCode.NotFound, "product specification attribute", "not found");
+            }
+
+            _specificationAttributeService.DeleteProductSpecificationAttribute(productSpecificationAttribute);
+
+            //activity log
+            _customerActivityService.InsertActivity("DeleteProductSpecificationAttribute", _localizationService.GetResource("ActivityLog.DeleteProductSpecificationAttribute"), productSpecificationAttribute.Id.ToString());
+
+            return new RawJsonActionResult("{}");
+        }
+    }
+}

--- a/Nop.Plugin.Api/Controllers/SpecificationAttributesController.cs
+++ b/Nop.Plugin.Api/Controllers/SpecificationAttributesController.cs
@@ -1,0 +1,258 @@
+﻿using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.AspNetCore.Mvc;
+using Nop.Core.Domain.Catalog;
+using Nop.Plugin.Api.Attributes;
+using Nop.Plugin.Api.Constants;
+using Nop.Plugin.Api.Delta;
+using Nop.Plugin.Api.DTOs.Errors;
+using Nop.Plugin.Api.DTOs.SpecificationAttributes;
+using Nop.Plugin.Api.Helpers;
+using Nop.Plugin.Api.JSON.ActionResults;
+using Nop.Plugin.Api.JSON.Serializers;
+using Nop.Plugin.Api.ModelBinders;
+using Nop.Plugin.Api.Models.ProductSpecificationAttributes;
+using Nop.Plugin.Api.Models.SpecificationAttributes;
+using Nop.Plugin.Api.Services;
+using Nop.Services.Catalog;
+using Nop.Services.Customers;
+using Nop.Services.Discounts;
+using Nop.Services.Localization;
+using Nop.Services.Logging;
+using Nop.Services.Media;
+using Nop.Services.Security;
+using Nop.Services.Stores;
+using System;
+using System.Linq;
+using System.Net;
+
+namespace Nop.Plugin.Api.Controllers
+{
+    [ApiAuthorize(Policy = JwtBearerDefaults.AuthenticationScheme, AuthenticationSchemes = JwtBearerDefaults.AuthenticationScheme)]
+    public class SpecificationAttributesController : BaseApiController
+    {
+        private readonly ISpecificationAttributeService _specificationAttributeService;
+        private readonly ISpecificationAttributeApiService _specificationAttributeApiService;
+        private readonly IDTOHelper _dtoHelper;
+
+        public SpecificationAttributesController(IJsonFieldsSerializer jsonFieldsSerializer, 
+                                  ICustomerActivityService customerActivityService,
+                                  ILocalizationService localizationService,
+                                  IAclService aclService,
+                                  IStoreMappingService storeMappingService,
+                                  IStoreService storeService,
+                                  ICustomerService customerService,
+                                  IDiscountService discountService,
+                                  IPictureService pictureService,
+                                  ISpecificationAttributeService specificationAttributeService,
+                                  ISpecificationAttributeApiService specificationAttributesApiService,
+                                  IDTOHelper dtoHelper) : base(jsonFieldsSerializer, aclService, customerService, storeMappingService, storeService, discountService, customerActivityService, localizationService, pictureService)
+        {
+            _specificationAttributeService = specificationAttributeService;
+            _specificationAttributeApiService = specificationAttributesApiService;
+            _dtoHelper = dtoHelper;
+        }
+
+        /// <summary>
+        /// Receive a list of all specification attributes
+        /// </summary>
+        /// <response code="200">OK</response>
+        /// <response code="400">Bad Request</response>
+        /// <response code="401">Unauthorized</response>
+        [HttpGet]
+        [Route("/api/specificationattributes")]
+        [ProducesResponseType(typeof(SpecificationAttributesRootObjectDto), (int)HttpStatusCode.OK)]
+        [ProducesResponseType(typeof(ErrorsRootObject), (int)HttpStatusCode.BadRequest)]
+        [ProducesResponseType(typeof(string), (int)HttpStatusCode.Unauthorized)]
+        [GetRequestsErrorInterceptorActionFilter]
+        public IActionResult GetSpecificationAttributes(SpecifcationAttributesParametersModel parameters)
+        {
+            if (parameters.Limit < Configurations.MinLimit || parameters.Limit > Configurations.MaxLimit)
+            {
+                return Error(HttpStatusCode.BadRequest, "limit", "invalid limit parameter");
+            }
+
+            if (parameters.Page < Configurations.DefaultPageValue)
+            {
+                return Error(HttpStatusCode.BadRequest, "page", "invalid page parameter");
+            }
+
+            var specificationAttribtues = _specificationAttributeApiService.GetSpecificationAttributes(limit: parameters.Limit, page: parameters.Page, sinceId: parameters.SinceId);
+
+            var specificationAttributeDtos = specificationAttribtues.Select(x => _dtoHelper.PrepareSpecificationAttributeDto(x)).ToList();
+
+            var specificationAttributesRootObject = new SpecificationAttributesRootObjectDto()
+            {
+                SpecificationAttributes = specificationAttributeDtos
+            };
+
+            var json = _jsonFieldsSerializer.Serialize(specificationAttributesRootObject, parameters.Fields);
+
+            return new RawJsonActionResult(json);
+        }
+
+        /// <summary>
+        /// Receive a count of all specification attributes
+        /// </summary>
+        /// <response code="200">OK</response>
+        /// <response code="401">Unauthorized</response>
+        [HttpGet]
+        [Route("/api/specificationattributes/count")]
+        [ProducesResponseType(typeof(SpecificationAttributesCountRootObject), (int)HttpStatusCode.OK)]        
+        [ProducesResponseType(typeof(string), (int)HttpStatusCode.Unauthorized)]
+        [ProducesResponseType(typeof(ErrorsRootObject), (int)HttpStatusCode.BadRequest)]
+        [GetRequestsErrorInterceptorActionFilter]
+        public IActionResult GetSpecificationAttributesCount(SpecifcationAttributesCountParametersModel parameters)
+        {
+            var specificationAttributesCount = _specificationAttributeService.GetSpecificationAttributes().Count();
+
+            var specificationAttributesCountRootObject = new SpecificationAttributesCountRootObject()
+            {
+                Count = specificationAttributesCount
+            };
+
+            return Ok(specificationAttributesCountRootObject);
+        }
+
+        /// <summary>
+        /// Retrieve specification attribute by spcified id
+        /// </summary>
+        /// <param name="id">Id of the specification  attribute</param>
+        /// <param name="fields">Fields from the specification attribute you want your json to contain</param>
+        /// <response code="200">OK</response>
+        /// <response code="404">Not Found</response>
+        /// <response code="401">Unauthorized</response>
+        [HttpGet]
+        [Route("/api/specificationattributes/{id}")]
+        [ProducesResponseType(typeof(SpecificationAttributesRootObjectDto), (int)HttpStatusCode.OK)]
+        [ProducesResponseType(typeof(string), (int)HttpStatusCode.Unauthorized)]
+        [ProducesResponseType(typeof(ErrorsRootObject), (int)HttpStatusCode.BadRequest)]
+        [ProducesResponseType(typeof(string), (int)HttpStatusCode.NotFound)]
+        [GetRequestsErrorInterceptorActionFilter]
+        public IActionResult GetSpecificationAttributeById(int id, string fields = "")
+        {
+            if (id <= 0)
+            {
+                return Error(HttpStatusCode.BadRequest, "id", "invalid id");
+            }
+
+            var specificationAttribute = _specificationAttributeService.GetSpecificationAttributeById(id);
+
+            if (specificationAttribute == null)
+            {
+                return Error(HttpStatusCode.NotFound, "specification attribute", "not found");
+            }
+
+            var specificationAttributeDto = _dtoHelper.PrepareSpecificationAttributeDto(specificationAttribute);
+
+            var specificationAttributesRootObject = new SpecificationAttributesRootObjectDto();
+            specificationAttributesRootObject.SpecificationAttributes.Add(specificationAttributeDto);
+
+            var json = _jsonFieldsSerializer.Serialize(specificationAttributesRootObject, fields);
+
+            return new RawJsonActionResult(json);
+        }
+
+        [HttpPost]
+        [Route("/api/specificationattributes")]
+        [ProducesResponseType(typeof(SpecificationAttributesRootObjectDto), (int)HttpStatusCode.OK)]
+        [ProducesResponseType(typeof(string), (int)HttpStatusCode.Unauthorized)]
+        [ProducesResponseType(typeof(ErrorsRootObject), (int)HttpStatusCode.BadRequest)]
+        [ProducesResponseType(typeof(string), (int)HttpStatusCode.NotFound)]
+        [ProducesResponseType(typeof(ErrorsRootObject), 422)]
+        public IActionResult CreateSpecificationAttribute([ModelBinder(typeof(JsonModelBinder<SpecificationAttributeDto>))] Delta<SpecificationAttributeDto> specificaitonAttributeDelta)
+        {
+            // Here we display the errors if the validation has failed at some point.
+            if (!ModelState.IsValid)
+            {
+                return Error();
+            }
+
+            // Inserting the new product
+            var specificationAttribute = new SpecificationAttribute();
+            specificaitonAttributeDelta.Merge(specificationAttribute);
+
+            _specificationAttributeService.InsertSpecificationAttribute(specificationAttribute);
+
+            _customerActivityService.InsertActivity("AddNewSpecAttribute", _localizationService.GetResource("ActivityLog.AddNewSpecAttribute"), specificationAttribute.Id.ToString());
+
+            // Preparing the result dto of the new product
+            var specificationAttributeDto = _dtoHelper.PrepareSpecificationAttributeDto(specificationAttribute);
+
+            var specificationAttributesRootObjectDto = new SpecificationAttributesRootObjectDto();
+            specificationAttributesRootObjectDto.SpecificationAttributes.Add(specificationAttributeDto);
+
+            var json = _jsonFieldsSerializer.Serialize(specificationAttributesRootObjectDto, string.Empty);
+
+            return new RawJsonActionResult(json);
+        }
+
+        [HttpPut]
+        [Route("/api/specificationattributes/{id}")]
+        [ProducesResponseType(typeof(SpecificationAttributesRootObjectDto), (int)HttpStatusCode.OK)]
+        [ProducesResponseType(typeof(string), (int)HttpStatusCode.Unauthorized)]
+        [ProducesResponseType(typeof(ErrorsRootObject), (int)HttpStatusCode.BadRequest)]
+        [ProducesResponseType(typeof(string), (int)HttpStatusCode.NotFound)]
+        [ProducesResponseType(typeof(ErrorsRootObject), 422)]
+        public IActionResult UpdateSpecificationAttribute([ModelBinder(typeof(JsonModelBinder<SpecificationAttributeDto>))] Delta<SpecificationAttributeDto> specificationAttributeDelta)
+        {
+            // Here we display the errors if the validation has failed at some point.
+            if (!ModelState.IsValid)
+            {
+                return Error();
+            }
+
+            // We do not need to validate the product attribute id, because this will happen in the model binder using the dto validator.
+            int specificationAttributeId = specificationAttributeDelta.Dto.Id;
+
+            var specificationAttribute = _specificationAttributeService.GetSpecificationAttributeById(specificationAttributeId);
+            if (specificationAttribute == null)
+            {
+                return Error(HttpStatusCode.NotFound, "specification attribute", "not found");
+            }
+
+            specificationAttributeDelta.Merge(specificationAttribute);
+
+            _specificationAttributeService.UpdateSpecificationAttribute(specificationAttribute);
+          
+            _customerActivityService.InsertActivity("EditSpecAttribute", _localizationService.GetResource("ActivityLog.EditSpecAttribute"), specificationAttribute.Id.ToString());
+
+            // Preparing the result dto of the new product attribute
+            var specificationAttributeDto = _dtoHelper.PrepareSpecificationAttributeDto(specificationAttribute);
+
+            var specificatoinAttributesRootObjectDto = new SpecificationAttributesRootObjectDto();
+            specificatoinAttributesRootObjectDto.SpecificationAttributes.Add(specificationAttributeDto);
+
+            var json = _jsonFieldsSerializer.Serialize(specificatoinAttributesRootObjectDto, string.Empty);
+
+            return new RawJsonActionResult(json);
+        }
+
+        [HttpDelete]
+        [Route("/api/specificationattributes/{id}")]
+        [ProducesResponseType(typeof(void), (int)HttpStatusCode.OK)]
+        [ProducesResponseType(typeof(string), (int)HttpStatusCode.Unauthorized)]
+        [ProducesResponseType(typeof(ErrorsRootObject), (int)HttpStatusCode.BadRequest)]
+        [ProducesResponseType(typeof(string), (int)HttpStatusCode.NotFound)]
+        [ProducesResponseType(typeof(ErrorsRootObject), 422)]
+        public IActionResult DeleteSpecificationAttribute(int id)
+        {
+            if (id <= 0)
+            {
+                return Error(HttpStatusCode.BadRequest, "id", "invalid id");
+            }
+
+            var specificationAttribute = _specificationAttributeService.GetSpecificationAttributeById(id);
+            if (specificationAttribute == null)
+            {
+                return Error(HttpStatusCode.NotFound, "specification attribute", "not found");
+            }
+
+            _specificationAttributeService.DeleteSpecificationAttribute(specificationAttribute);
+
+            //activity log
+            _customerActivityService.InsertActivity("DeleteSpecAttribute", _localizationService.GetResource("ActivityLog.DeleteSpecAttribute"), specificationAttribute.Id.ToString());
+
+            return new RawJsonActionResult("{}");
+        }
+    }
+}

--- a/Nop.Plugin.Api/DTOs/Products/ProductDto.cs
+++ b/Nop.Plugin.Api/DTOs/Products/ProductDto.cs
@@ -6,6 +6,7 @@ using Nop.Core.Domain.Catalog;
 using Nop.Plugin.Api.Attributes;
 using Nop.Plugin.Api.DTOs.Images;
 using Nop.Plugin.Api.DTOs.Languages;
+using Nop.Plugin.Api.DTOs.SpecificationAttributes;
 using Nop.Plugin.Api.Validators;
 
 namespace Nop.Plugin.Api.DTOs.Products
@@ -22,6 +23,7 @@ namespace Nop.Plugin.Api.DTOs.Products
         private List<LocalizedNameDto> _localizedNames;
         private List<ImageMappingDto> _images;
         private List<ProductAttributeMappingDto> _productAttributeMappings;
+        private List<ProductSpecificationAttributeDto> _productSpecificationAttributes;
         private List<int> _associatedProductIds;
         private List<string> _tags;
 
@@ -590,6 +592,19 @@ namespace Nop.Plugin.Api.DTOs.Products
             set
             {
                 _productAttributeMappings = value;
+            }
+        }
+
+        [JsonProperty("product_specification_attributes")]
+        public List<ProductSpecificationAttributeDto> ProductSpecificationAttributes
+        {
+            get
+            {
+                return _productSpecificationAttributes;
+            }
+            set
+            {
+                _productSpecificationAttributes = value;
             }
         }
 

--- a/Nop.Plugin.Api/DTOs/SpecificationAttributes/ProductSpecificationAttributeDto.cs
+++ b/Nop.Plugin.Api/DTOs/SpecificationAttributes/ProductSpecificationAttributeDto.cs
@@ -1,0 +1,83 @@
+﻿using FluentValidation.Attributes;
+using Newtonsoft.Json;
+using Nop.Core.Domain.Catalog;
+using Nop.Plugin.Api.Validators;
+using System;
+
+namespace Nop.Plugin.Api.DTOs.SpecificationAttributes
+{
+    [JsonObject(Title = "product_specification_attribute")]
+    [Validator(typeof(ProductSpecificationAttributeDtoValidator))]
+    public class ProductSpecificationAttributeDto
+    {
+        /// <summary>
+        /// Gets or sets the id
+        /// </summary>
+        [JsonProperty("id")]
+        public int Id { get; set; }
+
+        /// <summary>
+        /// Gets or sets the product id
+        /// </summary>
+        [JsonProperty("product_id")]
+        public int ProductId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the attribute type ID
+        /// </summary>
+        [JsonProperty("attribute_type_id")]
+        public int AttributeTypeId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the specification attribute identifier
+        /// </summary>
+        [JsonProperty("specification_attribute_option_id")]
+        public int SpecificationAttributeOptionId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the custom value
+        /// </summary>
+        [JsonProperty("custom_value")]
+        public string CustomValue { get; set; }
+
+        /// <summary>
+        /// Gets or sets whether the attribute can be filtered by
+        /// </summary>
+        [JsonProperty("allow_filtering")]
+        public bool AllowFiltering { get; set; }
+
+        /// <summary>
+        /// Gets or sets whether the attribute will be shown on the product page
+        /// </summary>
+        [JsonProperty("show_on_product_page")]
+        public bool ShowOnProductPage { get; set; }
+
+        /// <summary>
+        /// Gets or sets the display order
+        /// </summary>
+        [JsonProperty("display_order")]
+        public int DisplayOrder { get; set; }
+
+        /// <summary>
+        /// Gets the attribute control type by casting the AttributeTypeId; sets the AttributeTypeId
+        /// </summary>
+        [JsonProperty("attribute_type")]
+        public string AttributeType
+        {
+            get
+            {
+                return ((SpecificationAttributeType)AttributeTypeId).ToString();
+            }
+            set
+            {
+                AttributeTypeId = (int)Enum.Parse(typeof(SpecificationAttributeType), value);
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets the specification attribute
+        /// </summary>
+        [JsonProperty("specification_attribute_option")]
+        public virtual SpecificationAttributeOptionDto SpecificationAttributeOption { get; set; }
+    }
+}

--- a/Nop.Plugin.Api/DTOs/SpecificationAttributes/ProductSpecificationAttributesCountRootObject.cs
+++ b/Nop.Plugin.Api/DTOs/SpecificationAttributes/ProductSpecificationAttributesCountRootObject.cs
@@ -1,0 +1,10 @@
+﻿using Newtonsoft.Json;
+
+namespace Nop.Plugin.Api.DTOs.SpecificationAttributes
+{
+    public class ProductSpecificationAttributesCountRootObject
+    {
+        [JsonProperty("count")]
+        public int Count { get; set; }
+    }
+}

--- a/Nop.Plugin.Api/DTOs/SpecificationAttributes/ProductSpecificationAttributesRootObjectDto.cs
+++ b/Nop.Plugin.Api/DTOs/SpecificationAttributes/ProductSpecificationAttributesRootObjectDto.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace Nop.Plugin.Api.DTOs.SpecificationAttributes
+{
+    public class ProductSpecificationAttributesRootObjectDto : ISerializableObject
+    {
+        public ProductSpecificationAttributesRootObjectDto()
+        {
+            ProductSpecificationAttributes = new List<ProductSpecificationAttributeDto>();
+        }
+
+        [JsonProperty("product_specification_attributes")]
+        public IList<ProductSpecificationAttributeDto> ProductSpecificationAttributes { get; set; }
+
+        public string GetPrimaryPropertyName()
+        {
+            return "product_specification_attributes";
+        }
+
+        public Type GetPrimaryPropertyType()
+        {
+            return typeof (ProductSpecificationAttributeDto);
+        }
+    }
+}

--- a/Nop.Plugin.Api/DTOs/SpecificationAttributes/SpecificationAttributeDto.cs
+++ b/Nop.Plugin.Api/DTOs/SpecificationAttributes/SpecificationAttributeDto.cs
@@ -1,0 +1,36 @@
+﻿using FluentValidation.Attributes;
+using Newtonsoft.Json;
+using Nop.Plugin.Api.Validators;
+using System.Collections.Generic;
+
+namespace Nop.Plugin.Api.DTOs.SpecificationAttributes
+{
+    [JsonObject(Title = "specification_attribute")]
+    [Validator(typeof(SpecificationAttributeDtoValidator))]
+    public class SpecificationAttributeDto
+    {
+        /// <summary>
+        /// Gets or sets the id
+        /// </summary>
+        [JsonProperty("id")]
+        public int Id { get; set; }
+
+        /// <summary>
+        /// Gets or sets the name
+        /// </summary>
+        [JsonProperty("name")]
+        public string Name { get; set; }
+
+        /// <summary>
+        /// Gets or sets the display order
+        /// </summary>
+        [JsonProperty("display_order")]
+        public int DisplayOrder { get; set; }
+
+        /// <summary>
+        /// Gets or sets the specification attribute options
+        /// </summary>
+        [JsonProperty("specification_attribute_options")]
+        public List<SpecificationAttributeOptionDto> SpecificationAttributeOptions { get; set; }
+    }
+}

--- a/Nop.Plugin.Api/DTOs/SpecificationAttributes/SpecificationAttributeOptionDto.cs
+++ b/Nop.Plugin.Api/DTOs/SpecificationAttributes/SpecificationAttributeOptionDto.cs
@@ -1,0 +1,41 @@
+﻿using FluentValidation.Attributes;
+using Newtonsoft.Json;
+using Nop.Plugin.Api.Validators;
+
+namespace Nop.Plugin.Api.DTOs.SpecificationAttributes
+{
+    [JsonObject(Title = "specification_attribute_option")]
+    [Validator(typeof(SpecificationAttributeOptionDtoValidator))]
+    public class SpecificationAttributeOptionDto
+    {
+        /// <summary>
+        /// Gets or sets the id
+        /// </summary>
+        [JsonProperty("id")]
+        public int Id { get; set; }
+
+        /// <summary>
+        /// Gets or sets the specification attribute identifier
+        /// </summary>
+        [JsonProperty("specification_attribute_id")]
+        public int SpecificationAttributeId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the name
+        /// </summary>
+        [JsonProperty("name")]
+        public string Name { get; set; }
+
+        /// <summary>
+        /// Gets or sets the color RGB value (used when you want to display "Color squares" instead of text)
+        /// </summary>
+        [JsonProperty("color_squares_rgb")]
+        public string ColorSquaresRgb { get; set; }
+
+        /// <summary>
+        /// Gets or sets the display order
+        /// </summary>
+        [JsonProperty("display_order")]
+        public int DisplayOrder { get; set; }
+    }
+}

--- a/Nop.Plugin.Api/DTOs/SpecificationAttributes/SpecificationAttributesCountRootObject.cs
+++ b/Nop.Plugin.Api/DTOs/SpecificationAttributes/SpecificationAttributesCountRootObject.cs
@@ -1,0 +1,10 @@
+﻿using Newtonsoft.Json;
+
+namespace Nop.Plugin.Api.DTOs.SpecificationAttributes
+{
+    public class SpecificationAttributesCountRootObject
+    {
+        [JsonProperty("count")]
+        public int Count { get; set; }
+    }
+}

--- a/Nop.Plugin.Api/DTOs/SpecificationAttributes/SpecificationAttributesRootObjectDto.cs
+++ b/Nop.Plugin.Api/DTOs/SpecificationAttributes/SpecificationAttributesRootObjectDto.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace Nop.Plugin.Api.DTOs.SpecificationAttributes
+{
+    public class SpecificationAttributesRootObjectDto : ISerializableObject
+    {
+        public SpecificationAttributesRootObjectDto()
+        {
+            SpecificationAttributes = new List<SpecificationAttributeDto>();
+        }
+
+        [JsonProperty("specification_attributes")]
+        public IList<SpecificationAttributeDto> SpecificationAttributes { get; set; }
+
+        public string GetPrimaryPropertyName()
+        {
+            return "specification_attributes";
+        }
+
+        public Type GetPrimaryPropertyType()
+        {
+            return typeof (SpecificationAttributeDto);
+        }
+    }
+}

--- a/Nop.Plugin.Api/Helpers/DTOHelper.cs
+++ b/Nop.Plugin.Api/Helpers/DTOHelper.cs
@@ -1,32 +1,33 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using Nop.Core;
+﻿using Nop.Core;
 using Nop.Core.Domain.Catalog;
 using Nop.Core.Domain.Directory;
 using Nop.Core.Domain.Localization;
-using Nop.Plugin.Api.DTOs.Products;
-using Nop.Services.Catalog;
-using Nop.Services.Seo;
-using Nop.Services.Security;
-using Nop.Services.Stores;
-using Nop.Plugin.Api.DTOs.Images;
 using Nop.Core.Domain.Media;
 using Nop.Core.Domain.Orders;
 using Nop.Core.Domain.Stores;
-using Nop.Plugin.Api.MappingExtensions;
 using Nop.Plugin.Api.DTOs.Categories;
 using Nop.Plugin.Api.DTOs.Customers;
+using Nop.Plugin.Api.DTOs.Images;
 using Nop.Plugin.Api.DTOs.Languages;
+using Nop.Plugin.Api.DTOs.OrderItems;
 using Nop.Plugin.Api.DTOs.Orders;
-using Nop.Plugin.Api.Services;
-using Nop.Services.Media;
+using Nop.Plugin.Api.DTOs.ProductAttributes;
+using Nop.Plugin.Api.DTOs.Products;
 using Nop.Plugin.Api.DTOs.ShoppingCarts;
+using Nop.Plugin.Api.DTOs.SpecificationAttributes;
 using Nop.Plugin.Api.DTOs.Stores;
+using Nop.Plugin.Api.MappingExtensions;
+using Nop.Plugin.Api.Services;
+using Nop.Services.Catalog;
 using Nop.Services.Directory;
 using Nop.Services.Localization;
-using Nop.Plugin.Api.DTOs.ProductAttributes;
-using Nop.Plugin.Api.DTOs.OrderItems;
+using Nop.Services.Media;
+using Nop.Services.Security;
+using Nop.Services.Seo;
+using Nop.Services.Stores;
+using System;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace Nop.Plugin.Api.Helpers
 {
@@ -78,6 +79,7 @@ namespace Nop.Plugin.Api.Helpers
 
             PrepareProductImages(product.ProductPictures, productDto);
             PrepareProductAttributes(product.ProductAttributeMappings, productDto);
+            PrepareProductSpecificationAttributes(product.ProductSpecificationAttributes, productDto);
 
             productDto.SeName = product.GetSeName();
             productDto.DiscountIds = product.AppliedDiscounts.Select(discount => discount.Id).ToList();
@@ -320,6 +322,32 @@ namespace Nop.Plugin.Api.Helpers
         public ProductAttributeDto PrepareProductAttributeDTO(ProductAttribute productAttribute)
         {
             return productAttribute.ToDto();
-        }        
+        }
+        
+        public void PrepareProductSpecificationAttributes(IEnumerable<ProductSpecificationAttribute> productSpecificationAttributes, ProductDto productDto)
+        {
+            if (productDto.ProductSpecificationAttributes == null)
+                productDto.ProductSpecificationAttributes = new List<ProductSpecificationAttributeDto>();
+
+            foreach (var productSpecificationAttribute in productSpecificationAttributes)
+            {
+                ProductSpecificationAttributeDto productSpecificationAttributeDto = PrepareProductSpecificationAttributeDto(productSpecificationAttribute);
+
+                if (productSpecificationAttributeDto != null)
+                {
+                    productDto.ProductSpecificationAttributes.Add(productSpecificationAttributeDto);
+                }
+            }
+        }
+
+        public ProductSpecificationAttributeDto PrepareProductSpecificationAttributeDto(ProductSpecificationAttribute productSpecificationAttribute)
+        {
+            return productSpecificationAttribute.ToDto();
+        }
+
+        public SpecificationAttributeDto PrepareSpecificationAttributeDto(SpecificationAttribute specificationAttribute)
+        {
+            return specificationAttribute.ToDto();
+        }
     }
 }

--- a/Nop.Plugin.Api/Helpers/IDTOHelper.cs
+++ b/Nop.Plugin.Api/Helpers/IDTOHelper.cs
@@ -9,6 +9,7 @@ using Nop.Plugin.Api.DTOs.Orders;
 using Nop.Plugin.Api.DTOs.ProductAttributes;
 using Nop.Plugin.Api.DTOs.Products;
 using Nop.Plugin.Api.DTOs.ShoppingCarts;
+using Nop.Plugin.Api.DTOs.SpecificationAttributes;
 using Nop.Plugin.Api.DTOs.Stores;
 
 namespace Nop.Plugin.Api.Helpers
@@ -23,5 +24,7 @@ namespace Nop.Plugin.Api.Helpers
         StoreDto PrepareStoreDTO(Store store);
         LanguageDto PrepateLanguageDto(Language language);
         ProductAttributeDto PrepareProductAttributeDTO(ProductAttribute productAttribute);
+        ProductSpecificationAttributeDto PrepareProductSpecificationAttributeDto(ProductSpecificationAttribute productSpecificationAttribute);
+        SpecificationAttributeDto PrepareSpecificationAttributeDto(SpecificationAttribute specificationAttribute);
     }
 }

--- a/Nop.Plugin.Api/Infrastructure/DependencyRegister.cs
+++ b/Nop.Plugin.Api/Infrastructure/DependencyRegister.cs
@@ -53,6 +53,7 @@ namespace Nop.Plugin.Api.Infrastructure
             builder.RegisterType<ProductAttributesApiService>().As<IProductAttributesApiService>().InstancePerLifetimeScope();
             builder.RegisterType<ProductPictureService>().As<IProductPictureService>().InstancePerLifetimeScope();
             builder.RegisterType<ProductAttributeConverter>().As<IProductAttributeConverter>().InstancePerLifetimeScope();
+            builder.RegisterType<SpecificationAttributesApiService>().As<ISpecificationAttributeApiService>().InstancePerLifetimeScope();
             builder.RegisterType<NewsLetterSubscriptionApiService>().As<INewsLetterSubscriptionApiService>().InstancePerLifetimeScope();
 
             builder.RegisterType<MappingHelper>().As<IMappingHelper>().InstancePerLifetimeScope();

--- a/Nop.Plugin.Api/MappingExtensions/SpecificationAttributeDtoMapping.cs
+++ b/Nop.Plugin.Api/MappingExtensions/SpecificationAttributeDtoMapping.cs
@@ -1,0 +1,24 @@
+﻿using Nop.Core.Domain.Catalog;
+using Nop.Plugin.Api.AutoMapper;
+using Nop.Plugin.Api.DTOs.SpecificationAttributes;
+
+namespace Nop.Plugin.Api.MappingExtensions
+{
+    public static class SpecificationAttributeDtoMappings
+    {
+        public static ProductSpecificationAttributeDto ToDto(this ProductSpecificationAttribute productSpecificationAttribute)
+        {
+            return productSpecificationAttribute.MapTo<ProductSpecificationAttribute, ProductSpecificationAttributeDto>();
+        }
+
+        public static SpecificationAttributeDto ToDto(this SpecificationAttribute specificationAttribute)
+        {
+            return specificationAttribute.MapTo<SpecificationAttribute, SpecificationAttributeDto>();
+        }
+
+        public static SpecificationAttributeOptionDto ToDto(this SpecificationAttributeOption specificationAttributeOption)
+        {
+            return specificationAttributeOption.MapTo<SpecificationAttributeOption, SpecificationAttributeOptionDto>();
+        }
+    }
+}

--- a/Nop.Plugin.Api/Models/ProductSpecificationAttributesParameters/ProductSpecificationAttributesCountParametersModel.cs
+++ b/Nop.Plugin.Api/Models/ProductSpecificationAttributesParameters/ProductSpecificationAttributesCountParametersModel.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.AspNetCore.Mvc;
+using Newtonsoft.Json;
+using Nop.Plugin.Api.ModelBinders;
+
+namespace Nop.Plugin.Api.Models.ProductSpecificationAttributes
+{
+    // JsonProperty is used only for swagger
+    [ModelBinder(typeof(ParametersModelBinder<ProductSpecifcationAttributesCountParametersModel>))]
+    public class ProductSpecifcationAttributesCountParametersModel
+    {
+        public ProductSpecifcationAttributesCountParametersModel()
+        {
+
+        }
+
+        /// <summary>
+        /// Product Id
+        /// </summary>
+        [JsonProperty("product_id")]
+        public int ProductId { get; set; }
+
+        /// <summary>
+        /// Specification Attribute Option Id
+        /// </summary>
+        [JsonProperty("specification_attribute_option_id")]
+        public int SpecificationAttributeOptionId { get; set; }
+    }
+}

--- a/Nop.Plugin.Api/Models/ProductSpecificationAttributesParameters/ProductSpecificationAttributesParametersModel.cs
+++ b/Nop.Plugin.Api/Models/ProductSpecificationAttributesParameters/ProductSpecificationAttributesParametersModel.cs
@@ -1,0 +1,67 @@
+﻿using Microsoft.AspNetCore.Mvc;
+using Newtonsoft.Json;
+using Nop.Plugin.Api.Constants;
+using Nop.Plugin.Api.ModelBinders;
+
+namespace Nop.Plugin.Api.Models.ProductSpecificationAttributes
+{
+    [ModelBinder(typeof(ParametersModelBinder<ProductSpecifcationAttributesParametersModel>))]
+    public class ProductSpecifcationAttributesParametersModel
+    {
+        public ProductSpecifcationAttributesParametersModel()
+        {
+            Limit = Configurations.DefaultLimit;
+            Page = Configurations.DefaultPageValue;
+            SinceId = Configurations.DefaultSinceId;
+            Fields = string.Empty;
+        }
+
+        /// <summary>
+        /// Product Id
+        /// </summary>
+        [JsonProperty("product_id")]
+        public int ProductId { get; set; }
+
+        /// <summary>
+        /// Specification Attribute Option Id
+        /// </summary>
+        [JsonProperty("specification_attribute_option_id")]
+        public int SpecificationAttributeOptionId { get; set; }
+
+        /// <summary>
+        /// Allow Filtering
+        /// </summary>
+        [JsonProperty("allow_filtering")]
+        public bool? AllowFiltering { get; set; }
+
+        /// <summary>
+        /// Show on Product Page
+        /// </summary>
+        [JsonProperty("show_on_product_page")]
+        public bool? ShowOnProductPage { get; set; }
+
+        /// <summary>
+        /// Amount of results (default: 50) (maximum: 250)
+        /// </summary>
+        [JsonProperty("limit")]
+        public int Limit { get; set; }
+
+        /// <summary>
+        /// Page to show (default: 1)
+        /// </summary>
+        [JsonProperty("page")]
+        public int Page { get; set; }
+
+        /// <summary>
+        /// Restrict results to after the specified ID
+        /// </summary>
+        [JsonProperty("since_id")]
+        public int SinceId { get; set; }
+
+        /// <summary>
+        /// comma-separated list of fields to include in the response
+        /// </summary>
+        [JsonProperty("fields")]
+        public string Fields { get; set; }
+    }
+}

--- a/Nop.Plugin.Api/Models/SpecificationAttributesParameters/SpecificationAttributesCountParametersModel.cs
+++ b/Nop.Plugin.Api/Models/SpecificationAttributesParameters/SpecificationAttributesCountParametersModel.cs
@@ -1,0 +1,16 @@
+﻿using Microsoft.AspNetCore.Mvc;
+using Newtonsoft.Json;
+using Nop.Plugin.Api.ModelBinders;
+
+namespace Nop.Plugin.Api.Models.SpecificationAttributes
+{
+    // JsonProperty is used only for swagger
+    [ModelBinder(typeof(ParametersModelBinder<SpecifcationAttributesCountParametersModel>))]
+    public class SpecifcationAttributesCountParametersModel
+    {
+        public SpecifcationAttributesCountParametersModel()
+        {
+
+        }
+    }
+}

--- a/Nop.Plugin.Api/Models/SpecificationAttributesParameters/SpecificationAttributesParametersModel.cs
+++ b/Nop.Plugin.Api/Models/SpecificationAttributesParameters/SpecificationAttributesParametersModel.cs
@@ -1,0 +1,42 @@
+﻿using Microsoft.AspNetCore.Mvc;
+using Newtonsoft.Json;
+using Nop.Plugin.Api.Constants;
+using Nop.Plugin.Api.ModelBinders;
+
+namespace Nop.Plugin.Api.Models.SpecificationAttributes
+{
+    [ModelBinder(typeof(ParametersModelBinder<SpecifcationAttributesParametersModel>))]
+    public class SpecifcationAttributesParametersModel
+    {
+        public SpecifcationAttributesParametersModel()
+        {
+            Limit = Configurations.DefaultLimit;
+            Page = Configurations.DefaultPageValue;
+            SinceId = Configurations.DefaultSinceId;
+        }
+
+        /// <summary>
+        /// Amount of results (default: 50) (maximum: 250)
+        /// </summary>
+        [JsonProperty("limit")]
+        public int Limit { get; set; }
+
+        /// <summary>
+        /// Page to show (default: 1)
+        /// </summary>
+        [JsonProperty("page")]
+        public int Page { get; set; }
+
+        /// <summary>
+        /// comma-separated list of fields to include in the response
+        /// </summary>
+        [JsonProperty("fields")]
+        public string Fields { get; set; }
+
+        /// <summary>
+        /// Restrict results to after the specified ID
+        /// </summary>
+        [JsonProperty("since_id")]
+        public int SinceId { get; set; }
+    }
+}

--- a/Nop.Plugin.Api/Services/ISpecificationAttributeApiService.cs
+++ b/Nop.Plugin.Api/Services/ISpecificationAttributeApiService.cs
@@ -1,0 +1,12 @@
+﻿using Nop.Core.Domain.Catalog;
+using Nop.Plugin.Api.Constants;
+using System.Collections.Generic;
+
+namespace Nop.Plugin.Api.Services
+{
+    public interface ISpecificationAttributeApiService
+    {
+        IList<ProductSpecificationAttribute> GetProductSpecificationAttributes(int? productId = null, int? specificationAttributeOptionId = null, bool? allowFiltering = null, bool? showOnProductPage = null, int limit = Configurations.DefaultLimit,  int page = Configurations.DefaultPageValue, int sinceId = Configurations.DefaultSinceId);
+        IList<SpecificationAttribute> GetSpecificationAttributes(int limit = Configurations.DefaultLimit, int page = Configurations.DefaultPageValue, int sinceId = Configurations.DefaultSinceId);
+    }
+}

--- a/Nop.Plugin.Api/Services/SpecificationAttributesApiService.cs
+++ b/Nop.Plugin.Api/Services/SpecificationAttributesApiService.cs
@@ -1,0 +1,69 @@
+﻿using Nop.Core.Data;
+using Nop.Core.Domain.Catalog;
+using Nop.Plugin.Api.Constants;
+using Nop.Plugin.Api.DataStructures;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Nop.Plugin.Api.Services
+{
+    public class SpecificationAttributesApiService : ISpecificationAttributeApiService
+    {
+        private readonly IRepository<ProductSpecificationAttribute> _productSpecificationAttributesRepository;
+        private readonly IRepository<SpecificationAttribute> _specificationAttributesRepository;
+
+        public SpecificationAttributesApiService(IRepository<ProductSpecificationAttribute> productSpecificationAttributesRepository, IRepository<SpecificationAttribute> specificationAttributesRepository)
+        {
+            _productSpecificationAttributesRepository = productSpecificationAttributesRepository;
+            _specificationAttributesRepository = specificationAttributesRepository;
+        }
+
+        public IList<ProductSpecificationAttribute> GetProductSpecificationAttributes(int? productId = null, int? specificationAttributeOptionId = null, bool? allowFiltering = null, bool? showOnProductPage = null, int limit = Configurations.DefaultLimit, int page = Configurations.DefaultPageValue, int sinceId = Configurations.DefaultSinceId)
+        {
+            var query = _productSpecificationAttributesRepository.Table;
+
+            if (productId > 0)
+            {
+                query = query.Where(psa => psa.ProductId == productId);
+            }
+
+            if (specificationAttributeOptionId > 0)
+            {
+                query = query.Where(psa => psa.SpecificationAttributeOptionId == specificationAttributeOptionId);
+            }
+
+            if (allowFiltering.HasValue)
+            {
+                query = query.Where(psa => psa.AllowFiltering == allowFiltering.Value);
+            }
+
+            if (showOnProductPage.HasValue)
+            {
+                query = query.Where(psa => psa.ShowOnProductPage == showOnProductPage.Value);
+            }
+
+            if (sinceId > 0)
+            {
+                query = query.Where(productAttribute => productAttribute.Id > sinceId);
+            }
+
+            query = query.OrderBy(x => x.Id);
+
+            return new ApiList<ProductSpecificationAttribute>(query, page - 1, limit);
+        }
+
+        public IList<SpecificationAttribute> GetSpecificationAttributes(int limit = Configurations.DefaultLimit, int page = Configurations.DefaultPageValue, int sinceId = Configurations.DefaultSinceId)
+        {
+            var query = _specificationAttributesRepository.Table;
+
+            if (sinceId > 0)
+            {
+                query = query.Where(x => x.Id > sinceId);
+            }
+
+            query = query.OrderBy(x => x.Id);
+
+            return new ApiList<SpecificationAttribute>(query, page - 1, limit);
+        }
+    }
+}

--- a/Nop.Plugin.Api/Validators/ProductSpecificationAttributeDtoValidator.cs
+++ b/Nop.Plugin.Api/Validators/ProductSpecificationAttributeDtoValidator.cs
@@ -1,0 +1,65 @@
+﻿using FluentValidation;
+using Nop.Core.Domain.Catalog;
+using Nop.Plugin.Api.DTOs.SpecificationAttributes;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Nop.Plugin.Api.Validators
+{
+    public class ProductSpecificationAttributeDtoValidator : AbstractValidator<ProductSpecificationAttributeDto>
+    {
+        public ProductSpecificationAttributeDtoValidator(string httpMethod, Dictionary<string, object> passedPropertyValuePaires)
+        {
+            if (string.IsNullOrEmpty(httpMethod) || httpMethod.Equals("post", StringComparison.InvariantCultureIgnoreCase))
+            {
+                //apply "create" rules
+                RuleFor(x => x.Id).Equal(0).WithMessage("id must be zero or null for new records");
+
+                ApplyProductIdRule();
+                ApplyAttributeTypeIdRule();
+
+                if (passedPropertyValuePaires.ContainsKey("specification_attribute_option_id"))
+                {
+                    ApplySpecificationAttributeOptoinIdRule();
+                }
+            }
+            else if (httpMethod.Equals("put", StringComparison.InvariantCultureIgnoreCase))
+            {
+                //apply "update" rules
+                RuleFor(x => x.Id).GreaterThan(0).WithMessage("invalid id");
+
+                if (passedPropertyValuePaires.ContainsKey("product_id"))
+                {
+                    ApplyProductIdRule();
+                }
+
+                if (passedPropertyValuePaires.ContainsKey("attribute_type_id"))
+                {
+                    ApplyAttributeTypeIdRule();
+                }
+
+                if (passedPropertyValuePaires.ContainsKey("specification_attribute_option_id"))
+                {
+                    ApplySpecificationAttributeOptoinIdRule();
+                }
+            }
+        }
+
+        private void ApplyProductIdRule()
+        {
+            RuleFor(x => x.ProductId).GreaterThan(0).WithMessage("invalid product id");
+        }
+
+        private void ApplyAttributeTypeIdRule()
+        {
+            var specificationAttributeTypes = (SpecificationAttributeType[])Enum.GetValues(typeof(SpecificationAttributeType));
+            RuleFor(x => x.AttributeTypeId).InclusiveBetween((int)specificationAttributeTypes.First(), (int)specificationAttributeTypes.Last()).WithMessage("invalid attribute type id");
+        }
+
+        private void ApplySpecificationAttributeOptoinIdRule()
+        {
+            RuleFor(x => x.SpecificationAttributeOptionId).GreaterThan(0).WithMessage("invalid specification attribute option id");
+        }
+    }
+}

--- a/Nop.Plugin.Api/Validators/SpecificationAttributeDtoValidator.cs
+++ b/Nop.Plugin.Api/Validators/SpecificationAttributeDtoValidator.cs
@@ -1,0 +1,32 @@
+﻿using FluentValidation;
+using Nop.Plugin.Api.DTOs.SpecificationAttributes;
+using System;
+using System.Collections.Generic;
+
+namespace Nop.Plugin.Api.Validators
+{
+    public class SpecificationAttributeDtoValidator : AbstractValidator<SpecificationAttributeDto>
+    {
+        public SpecificationAttributeDtoValidator(string httpMethod, Dictionary<string, object> passedPropertyValuePaires)
+        {
+            if (string.IsNullOrEmpty(httpMethod) || httpMethod.Equals("post", StringComparison.InvariantCultureIgnoreCase))
+            {
+                //apply "create" rules
+                RuleFor(x => x.Id).Equal(0).WithMessage("id must be zero or null for new records");
+
+                ApplyNameRule();
+            }
+            else if (httpMethod.Equals("put", StringComparison.InvariantCultureIgnoreCase))
+            {
+                //apply "update" rules
+                RuleFor(x => x.Id).GreaterThan(0).WithMessage("invalid id");
+                ApplyNameRule();
+            }
+        }
+
+        private void ApplyNameRule()
+        {
+            RuleFor(x => x.Name).NotEmpty().WithMessage("invalid name");
+        }
+    }
+}

--- a/Nop.Plugin.Api/Validators/SpecificationAttributeOptionDtoValidator.cs
+++ b/Nop.Plugin.Api/Validators/SpecificationAttributeOptionDtoValidator.cs
@@ -1,0 +1,47 @@
+﻿using FluentValidation;
+using Nop.Plugin.Api.DTOs.SpecificationAttributes;
+using System;
+using System.Collections.Generic;
+
+namespace Nop.Plugin.Api.Validators
+{
+    public class SpecificationAttributeOptionDtoValidator : AbstractValidator<SpecificationAttributeOptionDto>
+    {
+        public SpecificationAttributeOptionDtoValidator(string httpMethod, Dictionary<string, object> passedPropertyValuePaires)
+        {
+            if (string.IsNullOrEmpty(httpMethod) || httpMethod.Equals("post", StringComparison.InvariantCultureIgnoreCase))
+            {
+                //apply "create" rules
+                RuleFor(x => x.Id).Equal(0).WithMessage("id must be zero or null for new records");
+
+                ApplyNameRule();
+                ApplySpecificationAttributeIdRule();
+            }
+            else if (httpMethod.Equals("put", StringComparison.InvariantCultureIgnoreCase))
+            {
+                //apply "update" rules
+                RuleFor(x => x.Id).GreaterThan(0).WithMessage("invalid id");
+
+                if (passedPropertyValuePaires.ContainsKey("name"))
+                {
+                    ApplyNameRule();
+                }
+
+                if (passedPropertyValuePaires.ContainsKey("specification_attribute_id"))
+                {
+                    ApplySpecificationAttributeIdRule();
+                }
+            }
+        }
+
+        private void ApplyNameRule()
+        {
+            RuleFor(x => x.Name).NotEmpty().WithMessage("invalid name");
+        }
+
+        private void ApplySpecificationAttributeIdRule()
+        {
+            RuleFor(x => x.SpecificationAttributeId).GreaterThan(0).WithMessage("invalid specification attribute id");
+        }
+    }
+}


### PR DESCRIPTION
This pull request exposes new API endpoints that allow for interacting with SpecificationAttributes and ProductSpecificationAttributes.  Additionally, it adds an array of ProductSpecificationAttributes to the product API responses.

The new endpoints are as follows:

- /api/specificationattributes
- /api/productspecificationattribtues

For the sake of consistency with existing code, the structure is based off of the ProductAttributes API implementation.  I did not add documentation.  I can add it, if needed, but I think the existing documentation is incomplete anyway (ex:  ProductAttributes), so that might be worth tackling as one larger task.