### PR TITLE
Nop commerce 4.10 dev

### DIFF
--- a/Nop.Plugin.Api/ApiMapperConfiguration.cs
+++ b/Nop.Plugin.Api/ApiMapperConfiguration.cs
@@ -140,7 +140,7 @@ namespace Nop.Plugin.Api
                     y => y.MapFrom(src => src.BillingAddress.GetWithDefault(x => x, new Address()).ToDto()))
                 .ForMember(x => x.ShippingAddress,
                     y => y.MapFrom(src => src.ShippingAddress.GetWithDefault(x => x, new Address()).ToDto()))
-                .ForMember(x => x.CustomerAddresses,
+                .ForMember(x => x.Addresses,
                     y =>
                         y.MapFrom(
                             src =>

--- a/Nop.Plugin.Api/ApiMapperConfiguration.cs
+++ b/Nop.Plugin.Api/ApiMapperConfiguration.cs
@@ -95,7 +95,7 @@ namespace Nop.Plugin.Api
             AutoMapperApiConfiguration.MapperConfigurationExpression.CreateMap<Order, OrderDto>()
                 .IgnoreAllNonExisting()
                 .ForMember(x => x.Id, y => y.MapFrom(src => src.Id))
-                .ForMember(x => x.OrderItemDtos, y => y.MapFrom(src => src.OrderItems.Select(x => x.ToDto())));
+                .ForMember(x => x.OrderItems, y => y.MapFrom(src => src.OrderItems.Select(x => x.ToDto())));
         }
 
         private void CreateAddressMap()

--- a/Nop.Plugin.Api/ApiStartup.cs
+++ b/Nop.Plugin.Api/ApiStartup.cs
@@ -10,6 +10,7 @@ namespace Nop.Plugin.Api
     using Microsoft.AspNetCore.Authentication.JwtBearer;
     using Microsoft.AspNetCore.Authorization;
     using Microsoft.AspNetCore.Builder;
+    using Microsoft.AspNetCore.Http;
     using Microsoft.AspNetCore.Rewrite;
     using Microsoft.EntityFrameworkCore;
     using Microsoft.Extensions.Configuration;
@@ -92,6 +93,13 @@ namespace Nop.Plugin.Api
             ////uncomment only if the client is an angular application that directly calls the oauth endpoint
             //// app.UseCors(Microsoft.Owin.Cors.CorsOptions.AllowAll);
             UseIdentityServer(app);
+
+            //need to enable rewind so we can read the request body multiple times (this should eventually be refactored, but both JsonModelBinder and all of the DTO validators need to read this stream)
+            app.Use(async (context, next) =>
+            {
+                context.Request.EnableBuffering();
+                await next();
+            });
         }
 
         private void UseIdentityServer(IApplicationBuilder app)

--- a/Nop.Plugin.Api/Controllers/CategoriesController.cs
+++ b/Nop.Plugin.Api/Controllers/CategoriesController.cs
@@ -253,10 +253,7 @@ namespace Nop.Plugin.Api.Controllers
                 return Error();
             }
 
-            // We do not need to validate the category id, because this will happen in the model binder using the dto validator.
-            var updateCategoryId = int.Parse(categoryDelta.Dto.Id);
-
-            var category = _categoryApiService.GetCategoryById(updateCategoryId);
+            var category = _categoryApiService.GetCategoryById(categoryDelta.Dto.Id);
 
             if (category == null)
             {

--- a/Nop.Plugin.Api/Controllers/CustomersController.cs
+++ b/Nop.Plugin.Api/Controllers/CustomersController.cs
@@ -245,7 +245,7 @@ namespace Nop.Plugin.Api.Controllers
             var newCustomer = _factory.Initialize();
             customerDelta.Merge(newCustomer);
 
-            foreach (var address in customerDelta.Dto.CustomerAddresses)
+            foreach (var address in customerDelta.Dto.Addresses)
             {
                 // we need to explicitly set the date as if it is not specified
                 // it will default to 01/01/0001 which is not supported by SQL Server and throws and exception
@@ -344,11 +344,11 @@ namespace Nop.Plugin.Api.Controllers
                 AddValidRoles(customerDelta, currentCustomer);
             }
 
-            if (customerDelta.Dto.CustomerAddresses.Count > 0)
+            if (customerDelta.Dto.Addresses.Count > 0)
             {
                 var currentCustomerAddresses = currentCustomer.Addresses.ToDictionary(address => address.Id, address => address);
 
-                foreach (var passedAddress in customerDelta.Dto.CustomerAddresses)
+                foreach (var passedAddress in customerDelta.Dto.Addresses)
                 {
                     var addressEntity = passedAddress.ToEntity();
 
@@ -493,7 +493,7 @@ namespace Nop.Plugin.Api.Controllers
 
         private void PopulateAddressCountryNames(CustomerDto newCustomerDto)
         {
-            foreach (var address in newCustomerDto.CustomerAddresses)
+            foreach (var address in newCustomerDto.Addresses)
             {
                 SetCountryName(address);
             }

--- a/Nop.Plugin.Api/Controllers/CustomersController.cs
+++ b/Nop.Plugin.Api/Controllers/CustomersController.cs
@@ -326,7 +326,7 @@ namespace Nop.Plugin.Api.Controllers
             //If the validation has passed the customerDelta object won't be null for sure so we don't need to check for this.
             
             // Updateting the customer
-            var currentCustomer = _customerApiService.GetCustomerEntityById(int.Parse(customerDelta.Dto.Id));
+            var currentCustomer = _customerApiService.GetCustomerEntityById(customerDelta.Dto.Id);
 
             if (currentCustomer == null)
             {
@@ -352,12 +352,11 @@ namespace Nop.Plugin.Api.Controllers
 
                 foreach (var passedAddress in customerDelta.Dto.CustomerAddresses)
                 {
-                    var passedAddressId = int.Parse(passedAddress.Id);
                     var addressEntity = passedAddress.ToEntity();
 
-                    if (currentCustomerAddresses.ContainsKey(passedAddressId))
+                    if (currentCustomerAddresses.ContainsKey(passedAddress.Id))
                     {
-                        _mappingHelper.Merge(passedAddress, currentCustomerAddresses[passedAddressId]);
+                        _mappingHelper.Merge(passedAddress, currentCustomerAddresses[passedAddress.Id]);
                     }
                     else
                     {

--- a/Nop.Plugin.Api/Controllers/CustomersController.cs
+++ b/Nop.Plugin.Api/Controllers/CustomersController.cs
@@ -323,8 +323,6 @@ namespace Nop.Plugin.Api.Controllers
                 return Error();
             }
 
-            //If the validation has passed the customerDelta object won't be null for sure so we don't need to check for this.
-            
             // Updateting the customer
             var currentCustomer = _customerApiService.GetCustomerEntityById(customerDelta.Dto.Id);
 

--- a/Nop.Plugin.Api/Controllers/OrdersController.cs
+++ b/Nop.Plugin.Api/Controllers/OrdersController.cs
@@ -392,7 +392,7 @@ namespace Nop.Plugin.Api.Controllers
                 return Error();
             }
 
-            var currentOrder = _orderApiService.GetOrderById(int.Parse(orderDelta.Dto.Id));
+            var currentOrder = _orderApiService.GetOrderById(orderDelta.Dto.Id);
 
             if (currentOrder == null)
             {
@@ -578,34 +578,36 @@ namespace Nop.Plugin.Api.Controllers
         {
             var shouldReturnError = false;
 
-            foreach (var orderItem in orderItems)
-            {
-                var orderItemDtoValidator = new OrderItemDtoValidator("post", null);
-                var validation = orderItemDtoValidator.Validate(orderItem);
+            //TODO:  4.10 Validation Refactor
 
-                if (validation.IsValid)
-                {
-                    if (orderItem.ProductId != null)
-                    {
-                        var product = _productService.GetProductById(orderItem.ProductId.Value);
+            //foreach (var orderItem in orderItems)
+            //{
+            //    var orderItemDtoValidator = new OrderItemDtoValidator("post", null);
+            //    var validation = orderItemDtoValidator.Validate(orderItem);
 
-                        if (product == null)
-                        {
-                            ModelState.AddModelError("order_item.product", string.Format("Product not found for order_item.product_id = {0}", orderItem.ProductId));
-                            shouldReturnError = true;
-                        }
-                    }
-                }
-                else
-                {
-                    foreach (var error in validation.Errors)
-                    {
-                        ModelState.AddModelError("order_item", error.ErrorMessage);
-                    }
+            //    if (validation.IsValid)
+            //    {
+            //        if (orderItem.ProductId != null)
+            //        {
+            //            var product = _productService.GetProductById(orderItem.ProductId.Value);
 
-                    shouldReturnError = true;
-                }
-            }
+            //            if (product == null)
+            //            {
+            //                ModelState.AddModelError("order_item.product", string.Format("Product not found for order_item.product_id = {0}", orderItem.ProductId));
+            //                shouldReturnError = true;
+            //            }
+            //        }
+            //    }
+            //    else
+            //    {
+            //        foreach (var error in validation.Errors)
+            //        {
+            //            ModelState.AddModelError("order_item", error.ErrorMessage);
+            //        }
+
+            //        shouldReturnError = true;
+            //    }
+            //}
 
             return shouldReturnError;
         }
@@ -667,7 +669,7 @@ namespace Nop.Plugin.Api.Controllers
         
         private bool ValidateAddress(AddressDto address, string addressKind)
         {
-            bool addressValid;
+            bool addressValid = true;
 
             if (address == null)
             {
@@ -676,15 +678,17 @@ namespace Nop.Plugin.Api.Controllers
             }
             else
             {
-                var addressValidator = new AddressDtoValidator();
-                var validationResult = addressValidator.Validate(address);
+                //TODO:  4.10 Validation Refactor
 
-                foreach (var validationFailure in validationResult.Errors)
-                {
-                    ModelState.AddModelError(addressKind, validationFailure.ErrorMessage);
-                }
+                //var addressValidator = new AddressDtoValidator();
+                //var validationResult = addressValidator.Validate(address);
 
-                addressValid = validationResult.IsValid;
+                //foreach (var validationFailure in validationResult.Errors)
+                //{
+                //    ModelState.AddModelError(addressKind, validationFailure.ErrorMessage);
+                //}
+
+                //addressValid = validationResult.IsValid;
             }
 
             return addressValid;

--- a/Nop.Plugin.Api/Controllers/ProductAttributesController.cs
+++ b/Nop.Plugin.Api/Controllers/ProductAttributesController.cs
@@ -203,10 +203,7 @@ namespace Nop.Plugin.Api.Controllers
                 return Error();
             }
 
-            // We do not need to validate the product attribute id, because this will happen in the model binder using the dto validator.
-            var productAttributeId = int.Parse(productAttributeDelta.Dto.Id);
-
-            var productAttribute = _productAttributesApiService.GetById(productAttributeId);
+            var productAttribute = _productAttributesApiService.GetById(productAttributeDelta.Dto.Id);
 
             if (productAttribute == null)
             {

--- a/Nop.Plugin.Api/Controllers/ProductsController.cs
+++ b/Nop.Plugin.Api/Controllers/ProductsController.cs
@@ -247,10 +247,7 @@ namespace Nop.Plugin.Api.Controllers
                 return Error();
             }
 
-            // We do not need to validate the product id, because this will happen in the model binder using the dto validator.
-            var productId = int.Parse(productDelta.Dto.Id);
-
-            var product = _productApiService.GetProductById(productId);
+            var product = _productApiService.GetProductById(productDelta.Dto.Id);
 
             if (product == null)
             {

--- a/Nop.Plugin.Api/Controllers/ShoppingCartItemsController.cs
+++ b/Nop.Plugin.Api/Controllers/ShoppingCartItemsController.cs
@@ -274,8 +274,7 @@ namespace Nop.Plugin.Api.Controllers
             }
 
             // We kno that the id will be valid integer because the validation for this happens in the validator which is executed by the model binder.
-            var shoppingCartItemForUpdate =
-                _shoppingCartItemApiService.GetShoppingCartItem(int.Parse(shoppingCartItemDelta.Dto.Id));
+            var shoppingCartItemForUpdate = _shoppingCartItemApiService.GetShoppingCartItem(shoppingCartItemDelta.Dto.Id);
 
             if (shoppingCartItemForUpdate == null)
             {

--- a/Nop.Plugin.Api/DTOs/AddressDto.cs
+++ b/Nop.Plugin.Api/DTOs/AddressDto.cs
@@ -1,19 +1,15 @@
 ﻿using System;
 using FluentValidation.Attributes;
 using Newtonsoft.Json;
+using Nop.Plugin.Api.DTOs.Base;
 using Nop.Plugin.Api.Validators;
 
 namespace Nop.Plugin.Api.DTOs
 {
     [JsonObject(Title = "address")]
     [Validator(typeof(AddressDtoValidator))]
-    public class AddressDto
+    public class AddressDto : BaseDto
     {
-        /// <summary>
-        /// Gets or sets the first name
-        /// </summary>
-        [JsonProperty("id")]
-        public string Id { get; set; }
         /// <summary>
         /// Gets or sets the first name
         /// </summary>

--- a/Nop.Plugin.Api/DTOs/Base/BaseDto.cs
+++ b/Nop.Plugin.Api/DTOs/Base/BaseDto.cs
@@ -1,0 +1,10 @@
+﻿using Newtonsoft.Json;
+
+namespace Nop.Plugin.Api.DTOs.Base
+{
+    public abstract class BaseDto
+    {
+        [JsonProperty("id")]
+        public int Id { get; set; }
+    }
+}

--- a/Nop.Plugin.Api/DTOs/Categories/CategoryDto.cs
+++ b/Nop.Plugin.Api/DTOs/Categories/CategoryDto.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using FluentValidation.Attributes;
 using Newtonsoft.Json;
+using Nop.Plugin.Api.DTOs.Base;
 using Nop.Plugin.Api.DTOs.Images;
 using Nop.Plugin.Api.DTOs.Languages;
 using Nop.Plugin.Api.Validators;
@@ -10,16 +11,13 @@ namespace Nop.Plugin.Api.DTOs.Categories
 {
     [Validator(typeof(CategoryDtoValidator))]
     [JsonObject(Title = "category")]
-    public class CategoryDto
+    public class CategoryDto : BaseDto
     {
         private ImageDto _imageDto;
         private List<LocalizedNameDto> _localizedNames;
         private List<int> _storeIds;
         private List<int> _discountIds;
         private List<int> _roleIds;
-
-        [JsonProperty("id")]
-        public string Id { get; set; }
 
         [JsonProperty("name")]
         public string Name { get; set; }

--- a/Nop.Plugin.Api/DTOs/CustomerRoles/CustomerRoleDto.cs
+++ b/Nop.Plugin.Api/DTOs/CustomerRoles/CustomerRoleDto.cs
@@ -1,16 +1,11 @@
 ﻿using Newtonsoft.Json;
+using Nop.Plugin.Api.DTOs.Base;
 
 namespace Nop.Plugin.Api.DTOs.CustomerRoles
 {
     [JsonObject(Title = "customer_role")]
-    public class CustomerRoleDto
+    public class CustomerRoleDto : BaseDto
     {
-        /// <summary>
-        /// Gets or sets the store ID
-        /// </summary>
-        [JsonProperty("id")]
-        public string Id { get; set; }
-
         /// <summary>
         /// Gets or sets the customer role name
         /// </summary>

--- a/Nop.Plugin.Api/DTOs/Customers/BaseCustomerDto.cs
+++ b/Nop.Plugin.Api/DTOs/Customers/BaseCustomerDto.cs
@@ -1,15 +1,13 @@
 ﻿using System;
 using System.Collections.Generic;
 using Newtonsoft.Json;
+using Nop.Plugin.Api.DTOs.Base;
 
 namespace Nop.Plugin.Api.DTOs.Customers
 {
-    public class BaseCustomerDto
+    public class BaseCustomerDto : BaseDto
     {
         private List<int> _roleIds;
-
-        [JsonProperty("id")]
-        public string Id { get; set; }
 
         [JsonProperty("username")]
         public string Username { get; set; }

--- a/Nop.Plugin.Api/DTOs/Customers/CustomerDto.cs
+++ b/Nop.Plugin.Api/DTOs/Customers/CustomerDto.cs
@@ -55,7 +55,7 @@ namespace Nop.Plugin.Api.DTOs.Customers
         /// Gets or sets customer addresses
         /// </summary>
         [JsonProperty("addresses")]
-        public ICollection<AddressDto> CustomerAddresses
+        public ICollection<AddressDto> Addresses
         {
             get
             {

--- a/Nop.Plugin.Api/DTOs/Languages/LanguageDto.cs
+++ b/Nop.Plugin.Api/DTOs/Languages/LanguageDto.cs
@@ -1,18 +1,13 @@
 ﻿using System.Collections.Generic;
 using Newtonsoft.Json;
+using Nop.Plugin.Api.DTOs.Base;
 
 namespace Nop.Plugin.Api.DTOs.Languages
 {
     [JsonObject(Title = "language")]
-    public class LanguageDto
+    public class LanguageDto : BaseDto
     {
         private List<int> _storeIds;
-
-        /// <summary>
-        /// Gets or sets the store ID
-        /// </summary>
-        [JsonProperty("id")]
-        public string Id { get; set; }
 
         /// <summary>
         /// Gets or sets the name

--- a/Nop.Plugin.Api/DTOs/NewsLetterSubscriptions/NewsLetterSubscriptionDto.cs
+++ b/Nop.Plugin.Api/DTOs/NewsLetterSubscriptions/NewsLetterSubscriptionDto.cs
@@ -1,17 +1,12 @@
 ﻿using System;
 using Newtonsoft.Json;
+using Nop.Plugin.Api.DTOs.Base;
 
 namespace Nop.Plugin.Api.DTOs.Categories
 {
     [JsonObject(Title = "news_letter_subscription")]
-    public class NewsLetterSubscriptionDto
+    public class NewsLetterSubscriptionDto : BaseDto
     {
-        /// <summary>
-        /// Gets or sets the id
-        /// </summary>
-        [JsonProperty("id")]
-        public string Id { get; set; }
-
         /// <summary>
         /// Gets or sets the email
         /// </summary>

--- a/Nop.Plugin.Api/DTOs/OrderItems/OrderItemDto.cs
+++ b/Nop.Plugin.Api/DTOs/OrderItems/OrderItemDto.cs
@@ -13,13 +13,13 @@ namespace Nop.Plugin.Api.DTOs.OrderItems
     [JsonObject(Title = "order_item")]
     public class OrderItemDto : BaseDto
     {
-        private List<ProductItemAttributeDto> _attributes;
+        private ICollection<ProductItemAttributeDto> _attributes;
 
         /// <summary>
         /// Gets or sets the selected attributes
         /// </summary>
         [JsonProperty("product_attributes")]
-        public List<ProductItemAttributeDto> Attributes
+        public ICollection<ProductItemAttributeDto> Attributes
         {
             get
             {

--- a/Nop.Plugin.Api/DTOs/OrderItems/OrderItemDto.cs
+++ b/Nop.Plugin.Api/DTOs/OrderItems/OrderItemDto.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using FluentValidation.Attributes;
 using Newtonsoft.Json;
 using Nop.Plugin.Api.Attributes;
+using Nop.Plugin.Api.DTOs.Base;
 using Nop.Plugin.Api.DTOs.Products;
 using Nop.Plugin.Api.Validators;
 
@@ -10,15 +11,9 @@ namespace Nop.Plugin.Api.DTOs.OrderItems
 {
     [Validator(typeof(OrderItemDtoValidator))]
     [JsonObject(Title = "order_item")]
-    public class OrderItemDto
+    public class OrderItemDto : BaseDto
     {
         private List<ProductItemAttributeDto> _attributes;
-
-        /// <summary>
-        /// Gets or sets the id
-        /// </summary>
-        [JsonProperty("id")]
-        public string Id { get; set; }
 
         /// <summary>
         /// Gets or sets the selected attributes

--- a/Nop.Plugin.Api/DTOs/Orders/OrderDto.cs
+++ b/Nop.Plugin.Api/DTOs/Orders/OrderDto.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using FluentValidation.Attributes;
 using Newtonsoft.Json;
+using Nop.Plugin.Api.DTOs.Base;
 using Nop.Plugin.Api.DTOs.Customers;
 using Nop.Plugin.Api.DTOs.OrderItems;
 using Nop.Plugin.Api.Validators;
@@ -10,15 +11,9 @@ namespace Nop.Plugin.Api.DTOs.Orders
 {
     [JsonObject(Title = "order")]
     [Validator(typeof(OrderDtoValidator))]
-    public class OrderDto
+    public class OrderDto : BaseDto
     {
         private ICollection<OrderItemDto> _orderItemDtos;
-
-        /// <summary>
-        /// Gets or sets a value indicating the order id
-        /// </summary>
-        [JsonProperty("id")]
-        public string Id { get; set; }
 
         [JsonProperty("store_id")]
         public int? StoreId { get; set; }

--- a/Nop.Plugin.Api/DTOs/Orders/OrderDto.cs
+++ b/Nop.Plugin.Api/DTOs/Orders/OrderDto.cs
@@ -13,7 +13,7 @@ namespace Nop.Plugin.Api.DTOs.Orders
     [Validator(typeof(OrderDtoValidator))]
     public class OrderDto : BaseDto
     {
-        private ICollection<OrderItemDto> _orderItemDtos;
+        private ICollection<OrderItemDto> _orderItems;
 
         [JsonProperty("store_id")]
         public int? StoreId { get; set; }
@@ -259,10 +259,18 @@ namespace Nop.Plugin.Api.DTOs.Orders
         /// Gets or sets order items
         /// </summary>
         [JsonProperty("order_items")]
-        public ICollection<OrderItemDto> OrderItemDtos
+        public ICollection<OrderItemDto> OrderItems
         {
-            get { return _orderItemDtos; }
-            set { _orderItemDtos = value; }
+            get
+            {
+                if (_orderItems == null)
+                {
+                    _orderItems = new List<OrderItemDto>();
+                }
+
+                return _orderItems;
+            }
+            set { _orderItems = value; }
         }
 
         /// <summary>

--- a/Nop.Plugin.Api/DTOs/ProductAttributes/ProductAttributeDto.cs
+++ b/Nop.Plugin.Api/DTOs/ProductAttributes/ProductAttributeDto.cs
@@ -1,19 +1,14 @@
 ﻿using FluentValidation.Attributes;
 using Newtonsoft.Json;
+using Nop.Plugin.Api.DTOs.Base;
 using Nop.Plugin.Api.Validators;
 
 namespace Nop.Plugin.Api.DTOs.ProductAttributes
 {
     [JsonObject(Title = "product_attribute")]
     [Validator(typeof(ProductAttributeDtoValidator))]
-    public class ProductAttributeDto
+    public class ProductAttributeDto : BaseDto
     {
-        /// <summary>
-        /// Gets or sets the product attribute id
-        /// </summary>
-        [JsonProperty("id")]
-        public string Id { get; set; }
-
         /// <summary>
         /// Gets or sets the name
         /// </summary>

--- a/Nop.Plugin.Api/DTOs/ProductCategoryMappings/ProductCategoryMappingsDto.cs
+++ b/Nop.Plugin.Api/DTOs/ProductCategoryMappings/ProductCategoryMappingsDto.cs
@@ -1,16 +1,14 @@
 ﻿using FluentValidation.Attributes;
 using Newtonsoft.Json;
+using Nop.Plugin.Api.DTOs.Base;
 using Nop.Plugin.Api.Validators;
 
 namespace Nop.Plugin.Api.DTOs.ProductCategoryMappings
 {
     [JsonObject(Title = "product_category_mapping")]
     [Validator(typeof(ProductCategoryMappingDtoValidator))]
-    public class ProductCategoryMappingDto
+    public class ProductCategoryMappingDto : BaseDto
     {
-        [JsonProperty("id")]
-        public int Id { get; set; }
-
         /// <summary>
         /// Gets or sets the product identifier
         /// </summary>

--- a/Nop.Plugin.Api/DTOs/ProductItemAttributeDto.cs
+++ b/Nop.Plugin.Api/DTOs/ProductItemAttributeDto.cs
@@ -1,13 +1,11 @@
 ﻿using Newtonsoft.Json;
+using Nop.Plugin.Api.DTOs.Base;
 
 namespace Nop.Plugin.Api.DTOs
 {
     [JsonObject(Title = "attribute")]
-    public class ProductItemAttributeDto
+    public class ProductItemAttributeDto : BaseDto
     {
-        [JsonProperty("id")]
-        public int Id { get; set; }
-
         [JsonProperty("value")]
         public string Value { get; set; }
     }

--- a/Nop.Plugin.Api/DTOs/Products/ProductAttributeMappingDto.cs
+++ b/Nop.Plugin.Api/DTOs/Products/ProductAttributeMappingDto.cs
@@ -2,20 +2,15 @@
 using System.Collections.Generic;
 using Newtonsoft.Json;
 using Nop.Core.Domain.Catalog;
+using Nop.Plugin.Api.DTOs.Base;
 
 namespace Nop.Plugin.Api.DTOs.Products
 {
     [JsonObject(Title = "attribute")]
     //[Validator(typeof(ProductDtoValidator))]
-    public class ProductAttributeMappingDto
+    public class ProductAttributeMappingDto : BaseDto
     {
         private List<ProductAttributeValueDto> _productAttributeValues;
-
-        /// <summary>
-        /// Gets or sets the product attribute identifier
-        /// </summary>
-        [JsonProperty("id")]
-        public int Id { get; set; }
 
         /// <summary>
         /// Gets or sets the product attribute identifier

--- a/Nop.Plugin.Api/DTOs/Products/ProductAttributeValueDto.cs
+++ b/Nop.Plugin.Api/DTOs/Products/ProductAttributeValueDto.cs
@@ -1,20 +1,15 @@
 ﻿using System;
 using Newtonsoft.Json;
 using Nop.Core.Domain.Catalog;
+using Nop.Plugin.Api.DTOs.Base;
 using Nop.Plugin.Api.DTOs.Images;
 
 namespace Nop.Plugin.Api.DTOs.Products
 {
     [JsonObject(Title = "attribute_value")]
     //[Validator(typeof(ProductDtoValidator))]
-    public class ProductAttributeValueDto
+    public class ProductAttributeValueDto : BaseDto
     {
-        /// <summary>
-        /// Gets or sets the product attribute value id
-        /// </summary>
-        [JsonProperty("id")]
-        public int Id { get; set; }
-
         /// <summary>
         /// Gets or sets the attribute value type identifier
         /// </summary>

--- a/Nop.Plugin.Api/DTOs/Products/ProductDto.cs
+++ b/Nop.Plugin.Api/DTOs/Products/ProductDto.cs
@@ -4,6 +4,7 @@ using FluentValidation.Attributes;
 using Newtonsoft.Json;
 using Nop.Core.Domain.Catalog;
 using Nop.Plugin.Api.Attributes;
+using Nop.Plugin.Api.DTOs.Base;
 using Nop.Plugin.Api.DTOs.Images;
 using Nop.Plugin.Api.DTOs.Languages;
 using Nop.Plugin.Api.Validators;
@@ -12,7 +13,7 @@ namespace Nop.Plugin.Api.DTOs.Products
 {
     [JsonObject(Title = "product")]
     [Validator(typeof(ProductDtoValidator))]
-    public class ProductDto
+    public class ProductDto : BaseDto
     {
         private int? _productTypeId;
         private List<int> _storeIds;
@@ -24,12 +25,6 @@ namespace Nop.Plugin.Api.DTOs.Products
         private List<ProductAttributeMappingDto> _productAttributeMappings;
         private List<int> _associatedProductIds;
         private List<string> _tags;
-
-        /// <summary>
-        /// Gets or sets the product id
-        /// </summary>
-        [JsonProperty("id")]
-        public string Id { get; set; }
 
         /// <summary>
         /// Gets or sets the values indicating whether this product is visible in catalog or search results.

--- a/Nop.Plugin.Api/DTOs/ShoppingCarts/ShoppingCartItemDto.cs
+++ b/Nop.Plugin.Api/DTOs/ShoppingCarts/ShoppingCartItemDto.cs
@@ -6,21 +6,16 @@ using Nop.Plugin.Api.DTOs.Customers;
 using Nop.Plugin.Api.DTOs.Products;
 using Nop.Plugin.Api.Validators;
 using System.Collections.Generic;
+using Nop.Plugin.Api.DTOs.Base;
 
 namespace Nop.Plugin.Api.DTOs.ShoppingCarts
 {
     [Validator(typeof(ShoppingCartItemDtoValidator))]
     [JsonObject(Title = "shopping_cart_item")]
-    public class ShoppingCartItemDto
+    public class ShoppingCartItemDto : BaseDto
     {
         private int? _shoppingCartTypeId;
         private List<ProductItemAttributeDto> _attributes;
-
-        /// <summary>
-        /// Gets or sets the id
-        /// </summary>
-        [JsonProperty("id")]
-        public string Id { get; set; }
 
         /// <summary>
         /// Gets or sets the selected attributes

--- a/Nop.Plugin.Api/DTOs/Stores/StoreDto.cs
+++ b/Nop.Plugin.Api/DTOs/Stores/StoreDto.cs
@@ -1,18 +1,13 @@
 ﻿using System.Collections.Generic;
 using Newtonsoft.Json;
+using Nop.Plugin.Api.DTOs.Base;
 
 namespace Nop.Plugin.Api.DTOs.Stores
 {
     [JsonObject(Title = "store")]
-    public class StoreDto
+    public class StoreDto : BaseDto
     {
         private List<int> _languageIds;
-
-        /// <summary>
-        /// Gets or sets the store ID
-        /// </summary>
-        [JsonProperty("id")]
-        public string Id { get; set; }
 
         /// <summary>
         /// Gets or sets the store name

--- a/Nop.Plugin.Api/Helpers/DTOHelper.cs
+++ b/Nop.Plugin.Api/Helpers/DTOHelper.cs
@@ -155,7 +155,7 @@ namespace Nop.Plugin.Api.Helpers
         {
             var orderDto = order.ToDto();
 
-            orderDto.OrderItemDtos = order.OrderItems.Select(PrepareOrderItemDTO).ToList();
+            orderDto.OrderItems = order.OrderItems.Select(PrepareOrderItemDTO).ToList();
 
             var customerDto = _customerApiService.GetCustomerById(order.Customer.Id);
 

--- a/Nop.Plugin.Api/Helpers/DTOHelper.cs
+++ b/Nop.Plugin.Api/Helpers/DTOHelper.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using Nop.Core.Domain.Catalog;
 using Nop.Core.Domain.Directory;

--- a/Nop.Plugin.Api/Helpers/IJsonHelper.cs
+++ b/Nop.Plugin.Api/Helpers/IJsonHelper.cs
@@ -6,7 +6,7 @@ namespace Nop.Plugin.Api.Helpers
 {
     public interface IJsonHelper
     {
-        Dictionary<string, object> GetJsonDictionaryFromStream(Stream stream, bool rewindStream);
+        Dictionary<string, object> GetRequestJsonDictionaryFromStream(Stream stream, bool rewindStream);
         string GetRootPropertyName<T>() where T : class, new();
     }
 }

--- a/Nop.Plugin.Api/Helpers/IJsonHelper.cs
+++ b/Nop.Plugin.Api/Helpers/IJsonHelper.cs
@@ -1,9 +1,12 @@
-﻿using System.Collections.Generic;
+﻿using Microsoft.AspNetCore.Http;
+using System.Collections.Generic;
+using System.IO;
 
 namespace Nop.Plugin.Api.Helpers
 {
     public interface IJsonHelper
     {
-        Dictionary<string, object> DeserializeToDictionary(string json);
+        Dictionary<string, object> GetJsonDictionaryFromStream(Stream stream, bool rewindStream);
+        string GetRootPropertyName<T>() where T : class, new();
     }
 }

--- a/Nop.Plugin.Api/Helpers/JsonHelper.cs
+++ b/Nop.Plugin.Api/Helpers/JsonHelper.cs
@@ -34,7 +34,7 @@ namespace Nop.Plugin.Api.Helpers
 
         #region Public Methods
 
-        public Dictionary<string, object> GetJsonDictionaryFromStream(Stream stream, bool rewindStream)
+        public Dictionary<string, object> GetRequestJsonDictionaryFromStream(Stream stream, bool rewindStream)
         {
             var json = GetRequestBodyString(stream, rewindStream);
             if (string.IsNullOrEmpty(json))

--- a/Nop.Plugin.Api/Helpers/JsonHelper.cs
+++ b/Nop.Plugin.Api/Helpers/JsonHelper.cs
@@ -1,14 +1,80 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
+using System.Text;
+using Microsoft.AspNetCore.Http;
 using Newtonsoft.Json.Linq;
+using Nop.Services.Localization;
 
 namespace Nop.Plugin.Api.Helpers
 {
-    // source - http://stackoverflow.com/questions/5546142/how-do-i-use-json-net-to-deserialize-into-nested-recursive-dictionary-and-list
     public class JsonHelper : IJsonHelper
     {
-        public Dictionary<string, object> DeserializeToDictionary(string json)
+
+        #region Private Fields
+
+        private readonly ILocalizationService _localizationService;
+
+        private readonly int _languageId;
+
+        #endregion
+
+        #region Constructors
+
+        public JsonHelper(ILanguageService languageService, ILocalizationService localizationService)
+        {
+            _localizationService = localizationService;
+
+            var language = languageService.GetAllLanguages().FirstOrDefault();
+            _languageId = language != null ? language.Id : 0;
+        }
+
+        #endregion
+
+        #region Public Methods
+
+        public Dictionary<string, object> GetJsonDictionaryFromStream(Stream stream, bool rewindStream)
+        {
+            var json = GetRequestBodyString(stream, rewindStream);
+            if (string.IsNullOrEmpty(json))
+            {
+                throw new InvalidOperationException(_localizationService.GetResource("Api.NoJsonProvided", _languageId, false));
+            }
+
+            var requestBodyDictioanry = DeserializeToDictionary(json);
+            if (requestBodyDictioanry == null || requestBodyDictioanry.Count == 0)
+            {
+                throw new InvalidOperationException(_localizationService.GetResource("Api.InvalidJsonFormat", _languageId, false));
+            }
+
+            return requestBodyDictioanry;
+        }
+
+        public string GetRootPropertyName<T>() where T : class, new()
+        {
+            var rootProperty = "";
+
+            var jsonObjectAttribute = ReflectionHelper.GetJsonObjectAttribute(typeof(T));
+            if (jsonObjectAttribute != null)
+            {
+                rootProperty = jsonObjectAttribute.Title;
+            }
+
+            if (string.IsNullOrEmpty(rootProperty))
+            {
+                throw new InvalidOperationException($"Error getting root property for type {typeof(T).FullName}.");
+            }
+
+            return rootProperty;
+        }
+
+        #endregion
+
+        #region Private Methods
+
+        // source - http://stackoverflow.com/questions/5546142/how-do-i-use-json-net-to-deserialize-into-nested-recursive-dictionary-and-list
+        private Dictionary<string, object> DeserializeToDictionary(string json)
         {
             //TODO: JToken.Parse could throw an exeption if not valid JSON string is passed
             try
@@ -18,9 +84,10 @@ namespace Nop.Plugin.Api.Helpers
             catch (Exception)
             {
                 return null;
-            } 
+            }
         }
 
+        // source - http://stackoverflow.com/questions/5546142/how-do-i-use-json-net-to-deserialize-into-nested-recursive-dictionary-and-list
         private object ToObject(JToken token)
         {
             switch (token.Type)
@@ -37,5 +104,24 @@ namespace Nop.Plugin.Api.Helpers
                     return ((JValue)token).Value;
             }
         }
+
+        private string GetRequestBodyString(Stream stream, bool rewindStream)
+        {
+            var result = "";
+
+            using (var streamReader = new StreamReader(stream, Encoding.UTF8, true, 1024, rewindStream))
+            {
+                result = streamReader.ReadToEnd();
+                if (rewindStream)
+                {
+                    stream.Position = 0; //reset position to allow reading again later
+                }
+            }
+
+            return result;
+        }
+
+        #endregion
+
     }
 }

--- a/Nop.Plugin.Api/Helpers/MappingHelper.cs
+++ b/Nop.Plugin.Api/Helpers/MappingHelper.cs
@@ -98,9 +98,7 @@ namespace Nop.Plugin.Api.Helpers
 
                     if (collection == null)
                     {
-                        var listType = typeof(List<>);
-                        var constructedListType = listType.MakeGenericType(collectionElementsType);
-                        collection = Activator.CreateInstance(constructedListType);
+                        collection = CreateEmptyList(collectionElementsType);
                         propertyToUpdate.SetValue(objectToBeUpdated, collection);
                     }
 
@@ -108,9 +106,7 @@ namespace Nop.Plugin.Api.Helpers
                     var collectionAsList = collection as IList;
                     if (collectionAsList == null)
                     {
-                        var listType = typeof(List<>);
-                        var constructedListType = listType.MakeGenericType(collectionElementsType);
-                        collectionAsList = (IList)Activator.CreateInstance(constructedListType);
+                        collectionAsList = CreateEmptyList(collectionElementsType);
 
                         var collectionAsEnumerable = collection as IEnumerable;
                         foreach (var collectionItem in collectionAsEnumerable)
@@ -119,6 +115,7 @@ namespace Nop.Plugin.Api.Helpers
                         }
 
                         collection = collectionAsList;
+                        propertyToUpdate.SetValue(objectToBeUpdated, collection);
                     }
 
                     foreach (var item in propertyValueAsCollection)
@@ -222,6 +219,15 @@ namespace Nop.Plugin.Api.Helpers
             SetValues(newProperties, newInstance, collectionElementsType, objectPropertyNameValuePairs, handleComplexTypeCollections);
 
             collection.Add(newInstance);
+        }
+
+        private IList CreateEmptyList(Type listItemType)
+        {
+            var listType = typeof(List<>);
+            var constructedListType = listType.MakeGenericType(listItemType);
+            var list = Activator.CreateInstance(constructedListType);
+
+            return list as IList;
         }
 
         // We need this method, because the default value of DateTime is not in the sql server DateTime range and we will get an exception if we use it.

--- a/Nop.Plugin.Api/Helpers/MappingHelper.cs
+++ b/Nop.Plugin.Api/Helpers/MappingHelper.cs
@@ -104,6 +104,23 @@ namespace Nop.Plugin.Api.Helpers
                         propertyToUpdate.SetValue(objectToBeUpdated, collection);
                     }
 
+                    //this is a hack to fix a bug when "collection" cannot be cast to IList (ex:  it's a HashSet for Order.OrderItems)
+                    var collectionAsList = collection as IList;
+                    if (collectionAsList == null)
+                    {
+                        var listType = typeof(List<>);
+                        var constructedListType = listType.MakeGenericType(collectionElementsType);
+                        collectionAsList = (IList)Activator.CreateInstance(constructedListType);
+
+                        var collectionAsEnumerable = collection as IEnumerable;
+                        foreach (var collectionItem in collectionAsEnumerable)
+                        {
+                            collectionAsList.Add(collectionItem);
+                        }
+
+                        collection = collectionAsList;
+                    }
+
                     foreach (var item in propertyValueAsCollection)
                     {
                         if (collectionElementsType.Namespace != "System")

--- a/Nop.Plugin.Api/Infrastructure/DependencyRegister.cs
+++ b/Nop.Plugin.Api/Infrastructure/DependencyRegister.cs
@@ -81,7 +81,6 @@ namespace Nop.Plugin.Api.Infrastructure
             builder.RegisterType<Maps.JsonPropertyMapper>().As<Maps.IJsonPropertyMapper>().InstancePerLifetimeScope();
 
             builder.RegisterType<HttpContextAccessor>().As<IHttpContextAccessor>().SingleInstance();
-            builder.RegisterType<ProductDtoValidator>().InstancePerLifetimeScope();
         }
 
         public virtual int Order

--- a/Nop.Plugin.Api/Infrastructure/DependencyRegister.cs
+++ b/Nop.Plugin.Api/Infrastructure/DependencyRegister.cs
@@ -7,6 +7,7 @@ using Nop.Web.Framework.Infrastructure.Extensions;
 
 namespace Nop.Plugin.Api.Infrastructure
 {
+    using Autofac.Core;
     using Microsoft.AspNetCore.Http;
     using Nop.Core.Domain.Catalog;
     using Nop.Core.Domain.Common;
@@ -21,6 +22,7 @@ namespace Nop.Plugin.Api.Infrastructure
     using Nop.Plugin.Api.Validators;
     //using Nop.Plugin.Api.WebHooks;
     using System;
+    using System.Collections.Generic;
 
     public class DependencyRegister : IDependencyRegistrar
     {
@@ -81,6 +83,8 @@ namespace Nop.Plugin.Api.Infrastructure
             builder.RegisterType<Maps.JsonPropertyMapper>().As<Maps.IJsonPropertyMapper>().InstancePerLifetimeScope();
 
             builder.RegisterType<HttpContextAccessor>().As<IHttpContextAccessor>().SingleInstance();
+
+            builder.RegisterType<Dictionary<string, object>>().SingleInstance();
         }
 
         public virtual int Order

--- a/Nop.Plugin.Api/Infrastructure/DependencyRegister.cs
+++ b/Nop.Plugin.Api/Infrastructure/DependencyRegister.cs
@@ -7,6 +7,7 @@ using Nop.Web.Framework.Infrastructure.Extensions;
 
 namespace Nop.Plugin.Api.Infrastructure
 {
+    using Microsoft.AspNetCore.Http;
     using Nop.Core.Domain.Catalog;
     using Nop.Core.Domain.Common;
     using Nop.Core.Domain.Customers;
@@ -78,6 +79,9 @@ namespace Nop.Plugin.Api.Infrastructure
             builder.RegisterType<ShoppingCartItemFactory>().As<IFactory<ShoppingCartItem>>().InstancePerLifetimeScope();
 
             builder.RegisterType<Maps.JsonPropertyMapper>().As<Maps.IJsonPropertyMapper>().InstancePerLifetimeScope();
+
+            builder.RegisterType<HttpContextAccessor>().As<IHttpContextAccessor>().SingleInstance();
+            builder.RegisterType<ProductDtoValidator>().InstancePerLifetimeScope();
         }
 
         public virtual int Order

--- a/Nop.Plugin.Api/ModelBinders/JsonModelBinder.cs
+++ b/Nop.Plugin.Api/ModelBinders/JsonModelBinder.cs
@@ -1,27 +1,25 @@
-﻿using System;
+﻿using Nop.Plugin.Api.Attributes;
+using Nop.Plugin.Api.Delta;
+using Nop.Plugin.Api.Helpers;
+using Nop.Plugin.Api.Validators;
+using Nop.Services.Localization;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using System.Threading.Tasks;
-using FluentValidation.Attributes;
-using FluentValidation.Results;
-using Nop.Plugin.Api.Attributes;
-using Nop.Plugin.Api.Helpers;
-using Nop.Plugin.Api.Delta;
-using Nop.Plugin.Api.Validators;
-using Nop.Services.Localization;
 
 namespace Nop.Plugin.Api.ModelBinders
 {
-    using System.IO;
     using Microsoft.AspNetCore.Mvc;
     using Microsoft.AspNetCore.Mvc.ModelBinding;
+    using System;
 
     public class JsonModelBinder<T> : IModelBinder where T : class, new()
     {
         private readonly IJsonHelper _jsonHelper;
         private readonly ILocalizationService _localizationService;
-        private readonly int FirstLanguageId;
+
+        private readonly int _languageId;
 
         public JsonModelBinder(IJsonHelper jsonHelper, ILocalizationService localizationService, ILanguageService languageService)
         {
@@ -30,38 +28,27 @@ namespace Nop.Plugin.Api.ModelBinders
 
             // Languages are ordered by display order so the first language will be with the smallest display order.
             var firstLanguage = languageService.GetAllLanguages().FirstOrDefault();
-
             if (firstLanguage != null)
             {
-                FirstLanguageId = firstLanguage.Id;
+                _languageId = firstLanguage.Id;
             }
             else
             {
-                FirstLanguageId = 0;
+                _languageId = 0;
             }
         }
 
         public Task BindModelAsync(ModelBindingContext bindingContext)
         {
-            var result = GetResult(bindingContext);
-
-            if (result == null)
+            var propertyValuePairs = GetPropertyValuePairs(bindingContext);
+            if (propertyValuePairs == null)
             {
                 bindingContext.Result = ModelBindingResult.Failed();
                 return Task.CompletedTask;
             }
-            
-            var rootProperty = GetRootProperty(bindingContext);
-
-            // Now we need to validate the root property.
-            ValidateRootProperty(bindingContext, result, rootProperty);
 
             if (bindingContext.ModelState.IsValid)
             {
-                // The validation for the key is in the Validate method.
-                var propertyValuePaires =
-                    (Dictionary<string, object>) result[rootProperty];
-
                 // You will have id parameter passed in the model binder only when you have put request.
                 // because get and delete do not use the model binder.
                 // Here we insert the id in the property value pairs to be validated by the dto validator in a later point.
@@ -71,19 +58,19 @@ namespace Nop.Plugin.Api.ModelBinders
                 {
                     // Here we insert the route data id in the value paires.
                     // If id is contained in the category json body the one from the route data is used instead.
-                    InsertIdInTheValuePaires(propertyValuePaires, routeDataId);
+                    InsertIdInTheValuePaires(propertyValuePairs, routeDataId);
                 }
 
                 // We need to call this method here so it will be certain that the routeDataId will be in the propertyValuePaires
                 // when the request is PUT.
-                ValidateValueTypes(bindingContext, propertyValuePaires);
+                ValidateValueTypes(bindingContext, propertyValuePairs);
 
                 Delta<T> delta = null;
 
                 if (bindingContext.ModelState.IsValid)
                 {
-                    delta = new Delta<T>(propertyValuePaires);
-                    ValidateModel(bindingContext, propertyValuePaires, delta.Dto);
+                    delta = new Delta<T>(propertyValuePairs);
+                    ValidateModel(bindingContext, propertyValuePairs, delta.Dto);
                 }
 
                 if (bindingContext.ModelState.IsValid)
@@ -104,32 +91,25 @@ namespace Nop.Plugin.Api.ModelBinders
             return Task.CompletedTask;
         }
 
-        private Dictionary<string, object> GetResult(ModelBindingContext bindingContext)
+        private Dictionary<string, object> GetPropertyValuePairs(ModelBindingContext bindingContext)
         {
             Dictionary<string, object> result = null;
 
-            var requestPayloadStream = bindingContext.ActionContext.HttpContext.Request.Body;
-
-            var requestPayload = string.Empty;
-
-            using (requestPayloadStream)
+            if (bindingContext.ModelState.IsValid)
             {
-                if (requestPayloadStream != null)
+                try
                 {
-                    var streamReader = new StreamReader(requestPayloadStream);
-                    requestPayload = streamReader.ReadToEnd();
-                    streamReader.Close();
+                    //get the root dictionary and root property (these will throw exceptions if they fail)
+                    result = _jsonHelper.GetJsonDictionaryFromStream(bindingContext.HttpContext.Request.Body, true);
+                    var rootPropertyName = _jsonHelper.GetRootPropertyName<T>();
+
+                    result = (Dictionary<string, object>)result[rootPropertyName];
+                }
+                catch (Exception ex)
+                {
+                    bindingContext.ModelState.AddModelError("json", ex.Message);
                 }
             }
-
-            // We need to check if the request has a payload.
-            CheckIfJsonIsProvided(bindingContext, requestPayload);
-
-            // After we are sure that the request payload and json are provided we need to deserialize this json.
-            result = DeserializeReqestPayload(bindingContext, requestPayload);
-
-            // Next we have to validate the json format.
-            ValidateJsonFormat(bindingContext, result);
 
             return result;
         }
@@ -157,11 +137,11 @@ namespace Nop.Plugin.Api.ModelBinders
             {
                 foreach (var invalidProperty in typeValidator.InvalidProperties)
                 {
-                    var key = string.Format(_localizationService.GetResource("Api.InvalidType", FirstLanguageId, false), invalidProperty);
+                    var key = string.Format(_localizationService.GetResource("Api.InvalidType", _languageId, false), invalidProperty);
 
                     if (!errors.ContainsKey(key))
                     {
-                        errors.Add(key, _localizationService.GetResource("Api.InvalidPropertyType", FirstLanguageId, false));
+                        errors.Add(key, _localizationService.GetResource("Api.InvalidPropertyType", _languageId, false));
                     }
                 }
             }
@@ -175,131 +155,21 @@ namespace Nop.Plugin.Api.ModelBinders
             }
         }
 
-        private void ValidateRootProperty(ModelBindingContext bindingContext, Dictionary<string, object> result, string rootProperty)
-        {
-            if (bindingContext.ModelState.IsValid)
-            {
-                var isRootPropertyValid = !string.IsNullOrEmpty(rootProperty) && result.ContainsKey(rootProperty);
-
-                if (!isRootPropertyValid)
-                {
-                    bindingContext.ModelState.AddModelError("rootProperty", _localizationService.GetResource("Api.InvalidRootProperty", FirstLanguageId, false));
-                }
-            }
-        }
-
-        private string GetRootProperty(ModelBindingContext bindingContext)
-        {
-            string rootProperty = null;
-
-            if (bindingContext.ModelState.IsValid)
-            {
-                var jsonObjectAttribute = ReflectionHelper.GetJsonObjectAttribute(typeof(T));
-
-                if (jsonObjectAttribute != null)
-                {
-                    rootProperty = jsonObjectAttribute.Title;
-                }
-            }
-
-            return rootProperty;
-        }
-
-        private void ValidateJsonFormat(ModelBindingContext bindingContext, Dictionary<string, object> result)
-        {
-            var isJsonFormatValid = result != null && result.Count > 0;
-
-            if (!isJsonFormatValid)
-            {
-                bindingContext.ModelState.AddModelError("json",
-                    _localizationService.GetResource("Api.InvalidJsonFormat", FirstLanguageId, false));
-            }
-        }
-
-        private Dictionary<string, object> DeserializeReqestPayload(ModelBindingContext bindingContext, string requestPayload)
-        {
-            Dictionary<string, object> result = null;
-
-            // Here we check if validation has passed to this point.
-            if (bindingContext.ModelState.IsValid)
-            {
-                result = _jsonHelper.DeserializeToDictionary(requestPayload);
-            }
-
-            return result;
-        }
-
-        private void CheckIfJsonIsProvided(ModelBindingContext bindingContext, string requestPayload)
-        {
-            if (string.IsNullOrEmpty(requestPayload) &&
-                bindingContext.ModelState.IsValid)
-            {
-                bindingContext.ModelState.AddModelError("json", _localizationService.GetResource("Api.NoJsonProvided", FirstLanguageId, false));
-            }
-        }
-        
         private void ValidateModel(ModelBindingContext bindingContext, Dictionary<string, object> propertyValuePaires, T dto)
         {
-            var validationResult = GetValidationResult(bindingContext.ActionContext, propertyValuePaires, dto);
+            // this method validates each property by checking if it has an attribute that inherits from BaseValidationAttribute
+            // these attribtues are different than FluentValidation attributes, so they need to be validated manually
 
-            if (!validationResult.IsValid)
-            {
-                foreach (var validationFailure in validationResult.Errors)
-                {
-                    bindingContext.ModelState.AddModelError(validationFailure.PropertyName,
-                        validationFailure.ErrorMessage);
-                }
-            }
-            else
-            {
-                HandleValidationAttributes(dto, bindingContext);
-            }
-        }
-
-        private ValidationResult GetValidationResult(ActionContext actionContext, Dictionary<string, object> propertyValuePaires, T dto)
-        {
-            var validationResult = new ValidationResult();
-
-            // Needed so we can call the get the validator.
-            var validatorAttribute =
-                typeof (T).GetCustomAttribute(typeof (ValidatorAttribute)) as ValidatorAttribute;
-
-            if (validatorAttribute != null)
-            {
-                var validatorType = validatorAttribute.ValidatorType;
-
-                // We need to pass the http method because there are some differences between the validation rules for post and put
-                // We need to pass the propertyValuePaires from the passed json because there are cases in which one field is required
-                // on post, but it is a valid case not to pass it when doing a put request.    
-                var validator = Activator.CreateInstance(validatorType,
-                    new object[]
-                    {
-                        //TODO: find this
-                        actionContext.HttpContext.Request.Method,
-                        propertyValuePaires
-                    });
-
-                // We know that the validator will be AbstractValidator<T> which means it will have Validate method.
-                validationResult = validatorType.GetMethod("Validate", new[] {typeof (T)})
-                    .Invoke(validator, new[] {dto}) as ValidationResult;
-            }
-
-            return validationResult;
-        }
-
-        private void HandleValidationAttributes(T dto, ModelBindingContext bindingContext)
-        {
             var dtoProperties = dto.GetType().GetProperties();
-
             foreach (var property in dtoProperties)
             {
                 // Check property type
-                var validationAttribute = property.PropertyType.GetCustomAttribute(typeof (BaseValidationAttribute)) as BaseValidationAttribute;
+                var validationAttribute = property.PropertyType.GetCustomAttribute(typeof(BaseValidationAttribute)) as BaseValidationAttribute;
 
                 // If not on property type, check the property itself.
                 if (validationAttribute == null)
                 {
-                    validationAttribute = property.GetCustomAttribute(typeof (BaseValidationAttribute)) as BaseValidationAttribute;
+                    validationAttribute = property.GetCustomAttribute(typeof(BaseValidationAttribute)) as BaseValidationAttribute;
                 }
 
                 if (validationAttribute != null)

--- a/Nop.Plugin.Api/ModelBinders/JsonModelBinder.cs
+++ b/Nop.Plugin.Api/ModelBinders/JsonModelBinder.cs
@@ -100,7 +100,7 @@ namespace Nop.Plugin.Api.ModelBinders
                 try
                 {
                     //get the root dictionary and root property (these will throw exceptions if they fail)
-                    result = _jsonHelper.GetJsonDictionaryFromStream(bindingContext.HttpContext.Request.Body, true);
+                    result = _jsonHelper.GetRequestJsonDictionaryFromStream(bindingContext.HttpContext.Request.Body, true);
                     var rootPropertyName = _jsonHelper.GetRootPropertyName<T>();
 
                     result = (Dictionary<string, object>)result[rootPropertyName];

--- a/Nop.Plugin.Api/Services/CategoryApiService.cs
+++ b/Nop.Plugin.Api/Services/CategoryApiService.cs
@@ -26,7 +26,7 @@ namespace Nop.Plugin.Api.Services
 
         public IList<Category> GetCategories(IList<int> ids = null,
             DateTime? createdAtMin = null, DateTime? createdAtMax = null, DateTime? updatedAtMin = null, DateTime? updatedAtMax = null,
-            int limit = Configurations.DefaultLimit, int page = Configurations.DefaultPageValue, int sinceId = Configurations.DefaultSinceId,
+            int limit = Configurations.DefaultLimit, int page = Configurations.DefaultPageValue, int sinceId = Configurations.DefaultSinceId, 
             int? productId = null,
             bool? publishedStatus = null)
         {

--- a/Nop.Plugin.Api/Validators/AddressDtoValidator.cs
+++ b/Nop.Plugin.Api/Validators/AddressDtoValidator.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.AspNetCore.Http;
 using Nop.Plugin.Api.DTOs;
 using Nop.Plugin.Api.Helpers;
+using System.Collections.Generic;
 
 namespace Nop.Plugin.Api.Validators
 {
@@ -9,7 +10,7 @@ namespace Nop.Plugin.Api.Validators
 
         #region Constructors
 
-        public AddressDtoValidator(IHttpContextAccessor httpContextAccessor, IJsonHelper jsonHelper) : base(httpContextAccessor, jsonHelper)
+        public AddressDtoValidator(IHttpContextAccessor httpContextAccessor, IJsonHelper jsonHelper, Dictionary<string, object> requestJsonDictionary) : base(httpContextAccessor, jsonHelper, requestJsonDictionary)
         {
             SetFirstNameRule();
             SetLastNameRule();

--- a/Nop.Plugin.Api/Validators/AddressDtoValidator.cs
+++ b/Nop.Plugin.Api/Validators/AddressDtoValidator.cs
@@ -1,37 +1,72 @@
-﻿using System;
-using System.Linq.Expressions;
-using FluentValidation;
+﻿using Microsoft.AspNetCore.Http;
 using Nop.Plugin.Api.DTOs;
+using Nop.Plugin.Api.Helpers;
 
 namespace Nop.Plugin.Api.Validators
 {
-    public class AddressDtoValidator : AbstractValidator<AddressDto>
+    public class AddressDtoValidator : BaseDtoValidator<AddressDto>
     {
-        public AddressDtoValidator()
+
+        #region Constructors
+
+        public AddressDtoValidator(IHttpContextAccessor httpContextAccessor, IJsonHelper jsonHelper) : base(httpContextAccessor, jsonHelper)
         {
-            SetNotNullOrEmptyRule(dto => dto.FirstName, "first_name required");
+            SetFirstNameRule();
+            SetLastNameRule();
+            SetEmailRule();
 
-            SetNotNullOrEmptyRule(dto => dto.LastName, "last_name required");
-
-            SetNotNullOrEmptyRule(dto => dto.Email, "email required");
-
-            SetNotNullOrEmptyRule(dto => dto.CountryId <= 0 ? string.Empty : dto.CountryId.ToString(), "country_id required");
-
-            SetNotNullOrEmptyRule(dto => dto.City, "city required");
-
-            SetNotNullOrEmptyRule(dto => dto.Address1, "address1 required");
-
-            SetNotNullOrEmptyRule(dto => dto.ZipPostalCode, "zip_postal_code required");
-
-            SetNotNullOrEmptyRule(dto => dto.PhoneNumber, "phone_number required");
+            SetAddress1Rule();
+            SetCityRule();
+            SetZipPostalCodeRule();
+            SetCountryIdRule();
+            SetPhoneNumberRule();
         }
-        
-        private void SetNotNullOrEmptyRule(Expression<Func<AddressDto, string>> expression, string errorMessage)
+
+        #endregion
+
+        #region Private Methods
+
+        private void SetAddress1Rule()
         {
-            RuleFor(expression)
-                   .NotNull()
-                   .NotEmpty()
-                   .WithMessage(errorMessage);
+            SetNotNullOrEmptyCreateOrUpdateRule(a => a.Address1, "address1 required", "address1");
         }
+
+        private void SetCityRule()
+        {
+            SetNotNullOrEmptyCreateOrUpdateRule(a => a.City, "city required", "city");
+        }
+
+        private void SetCountryIdRule()
+        {
+            SetGreaterThanZeroCreateOrUpdateRule(a => a.CountryId, "country_id required", "country_id");
+        }
+
+        private void SetEmailRule()
+        {
+            SetNotNullOrEmptyCreateOrUpdateRule(a => a.Email, "email required", "email");
+        }
+
+        private void SetFirstNameRule()
+        {
+            SetNotNullOrEmptyCreateOrUpdateRule(a => a.FirstName, "first_name required", "first_name");
+        }
+
+        private void SetLastNameRule()
+        {
+            SetNotNullOrEmptyCreateOrUpdateRule(a => a.LastName, "first_name required", "last_name");
+        }
+
+        private void SetPhoneNumberRule()
+        {
+            SetNotNullOrEmptyCreateOrUpdateRule(a => a.PhoneNumber, "phone_number required", "phone_number");
+        }
+
+        private void SetZipPostalCodeRule()
+        {
+            SetNotNullOrEmptyCreateOrUpdateRule(a => a.ZipPostalCode, "zip_postal_code required", "zip_postal_code");
+        }
+
+        #endregion
+
     }
 }

--- a/Nop.Plugin.Api/Validators/BaseDtoValidator.cs
+++ b/Nop.Plugin.Api/Validators/BaseDtoValidator.cs
@@ -1,8 +1,12 @@
 ﻿using FluentValidation;
 using Microsoft.AspNetCore.Http;
+using Nop.Core.Infrastructure;
 using Nop.Plugin.Api.DTOs.Base;
 using Nop.Plugin.Api.Helpers;
+using System;
 using System.Collections.Generic;
+using System.Linq.Expressions;
+using System.Net.Http;
 
 namespace Nop.Plugin.Api.Validators
 {
@@ -24,11 +28,17 @@ namespace Nop.Plugin.Api.Validators
         {
             _httpContextAccessor = httpContextAccessor;
             _jsonHelper = jsonHelper;
+
+            HttpMethod = new HttpMethod(_httpContextAccessor.HttpContext.Request.Method);
+
+            SetRequiredIdRule();
         }
 
         #endregion
 
         #region Protected Properties
+
+        protected HttpMethod HttpMethod { get; private set; }
 
         protected Dictionary<string, object> JsonDictionary
         {
@@ -47,13 +57,36 @@ namespace Nop.Plugin.Api.Validators
 
         #region Protected Methods
 
-        protected void SetRequiredIdRule()
+        protected void SetGreaterThanZeroCreateOrUpdateRule(Expression<Func<T, int?>> expression, string errorMessage, string jsonKey)
         {
-            RuleFor(x => x.Id)
+            if (HttpMethod == HttpMethod.Post || JsonDictionary.ContainsKey(jsonKey))
+            {
+                SetGreaterThanZeroRule(expression, errorMessage);
+            }
+        }
+
+        protected void SetGreaterThanZeroRule(Expression<Func<T, int?>> expression, string errorMessage)
+        {
+            RuleFor(expression)
                 .NotNull()
                 .NotEmpty()
-                .Must(id => id > 0)
-                .WithMessage("invalid id");
+                .Must(id => id > 0);
+        }
+
+        protected void SetNotNullOrEmptyCreateOrUpdateRule(Expression<Func<T, string>> expression, string errorMessage, string jsonKey)
+        {
+            if (HttpMethod == HttpMethod.Post || JsonDictionary.ContainsKey(jsonKey))
+            {
+                SetNotNullOrEmptyRule(expression, errorMessage);
+            }
+        }
+
+        protected void SetNotNullOrEmptyRule(Expression<Func<T, string>> expression, string errorMessage)
+        {
+            RuleFor(expression)
+                .NotNull()
+                .NotEmpty()
+                .WithMessage(errorMessage);
         }
 
         #endregion
@@ -64,9 +97,18 @@ namespace Nop.Plugin.Api.Validators
         {
             var jsonDictionary = _jsonHelper.GetJsonDictionaryFromStream(_httpContextAccessor.HttpContext.Request.Body, true);
             var rootPropertyName = _jsonHelper.GetRootPropertyName<T>();
-            jsonDictionary = (Dictionary<string, object>)jsonDictionary[rootPropertyName];
+
+            if (jsonDictionary.ContainsKey(rootPropertyName))
+            {
+                jsonDictionary = (Dictionary<string, object>)jsonDictionary[rootPropertyName];
+            }
 
             return jsonDictionary;
+        }
+
+        private void SetRequiredIdRule()
+        {
+            SetGreaterThanZeroCreateOrUpdateRule(x => x.Id, "invalid id", "id");
         }
 
         #endregion

--- a/Nop.Plugin.Api/Validators/BaseDtoValidator.cs
+++ b/Nop.Plugin.Api/Validators/BaseDtoValidator.cs
@@ -1,0 +1,75 @@
+﻿using FluentValidation;
+using Microsoft.AspNetCore.Http;
+using Nop.Plugin.Api.DTOs.Base;
+using Nop.Plugin.Api.Helpers;
+using System.Collections.Generic;
+
+namespace Nop.Plugin.Api.Validators
+{
+    public abstract class BaseDtoValidator<T> : AbstractValidator<T> where T : BaseDto, new()
+    {
+
+        #region Private Fields
+
+        private readonly IHttpContextAccessor _httpContextAccessor;
+        private readonly IJsonHelper _jsonHelper;
+
+        private Dictionary<string, object> _jsonDictionary;
+
+        #endregion
+
+        #region Constructors
+
+        public BaseDtoValidator(IHttpContextAccessor httpContextAccessor, IJsonHelper jsonHelper)
+        {
+            _httpContextAccessor = httpContextAccessor;
+            _jsonHelper = jsonHelper;
+        }
+
+        #endregion
+
+        #region Protected Properties
+
+        protected Dictionary<string, object> JsonDictionary
+        {
+            get
+            {
+                if (_jsonDictionary == null)
+                {
+                    _jsonDictionary = GetJsonDictionary();
+                }
+
+                return _jsonDictionary;
+            }
+        }
+
+        #endregion
+
+        #region Protected Methods
+
+        protected void SetRequiredIdRule()
+        {
+            RuleFor(x => x.Id)
+                .NotNull()
+                .NotEmpty()
+                .Must(id => id > 0)
+                .WithMessage("invalid id");
+        }
+
+        #endregion
+
+        #region Private Methods
+
+        private Dictionary<string, object> GetJsonDictionary()
+        {
+            var jsonDictionary = _jsonHelper.GetJsonDictionaryFromStream(_httpContextAccessor.HttpContext.Request.Body, true);
+            var rootPropertyName = _jsonHelper.GetRootPropertyName<T>();
+            jsonDictionary = (Dictionary<string, object>)jsonDictionary[rootPropertyName];
+
+            return jsonDictionary;
+        }
+
+        #endregion
+
+    }
+}

--- a/Nop.Plugin.Api/Validators/BaseDtoValidator.cs
+++ b/Nop.Plugin.Api/Validators/BaseDtoValidator.cs
@@ -42,8 +42,6 @@ namespace Nop.Plugin.Api.Validators
 
         protected IHttpContextAccessor HttpContextAccessor { get; private set; }
 
-        protected HttpMethod HttpMethod { get; private set; }
-
         protected Dictionary<string, object> RequestJsonDictionary
         {
             get
@@ -58,6 +56,12 @@ namespace Nop.Plugin.Api.Validators
         }
 
         protected IJsonHelper JsonHelper { get; private set; }
+
+        #endregion
+
+        #region Public Properties
+
+        public HttpMethod HttpMethod { get; set; }
 
         #endregion
 
@@ -77,7 +81,9 @@ namespace Nop.Plugin.Api.Validators
         protected Dictionary<string, object> GetRequestJsonDictionaryCollectionItemDictionary<TDto>(string collectionKey, TDto dto) where TDto : BaseDto
         {
             var collectionItems = (List<object>)RequestJsonDictionary[collectionKey];
-            var collectionItemDictionary = (Dictionary<string, object>)collectionItems.FirstOrDefault(x => ((int)(long)((Dictionary<string, object>)x)["id"]) == dto.Id);
+            var collectionItemDictionary = collectionItems.FirstOrDefault(x =>
+                ((Dictionary<string, object>)x).ContainsKey("id") && ((int)(long)((Dictionary<string, object>)x)["id"]) == dto.Id
+            ) as Dictionary<string, object>;
 
             return collectionItemDictionary;
         }

--- a/Nop.Plugin.Api/Validators/CategoryDtoValidator.cs
+++ b/Nop.Plugin.Api/Validators/CategoryDtoValidator.cs
@@ -1,39 +1,29 @@
-﻿using System;
-using System.Collections.Generic;
-using FluentValidation;
+﻿using Microsoft.AspNetCore.Http;
 using Nop.Plugin.Api.DTOs.Categories;
+using Nop.Plugin.Api.Helpers;
 
 namespace Nop.Plugin.Api.Validators
 {
-    public class CategoryDtoValidator : AbstractValidator<CategoryDto>
+    public class CategoryDtoValidator : BaseDtoValidator<CategoryDto>
     {
-        public CategoryDtoValidator(string httpMethod, Dictionary<string, object> passedPropertyValuePaires)
-        {
-            if (string.IsNullOrEmpty(httpMethod) || httpMethod.Equals("post", StringComparison.InvariantCultureIgnoreCase))
-            {
-                SetNameRule();
-            }
-            else if (httpMethod.Equals("put", StringComparison.InvariantCultureIgnoreCase))
-            {
-                RuleFor(x => x.Id)
-                        .NotNull()
-                        .NotEmpty()
-                        .Must(id => int.TryParse(id, out var parsedId) && parsedId > 0)
-                        .WithMessage("Invalid id");
 
-                if (passedPropertyValuePaires.ContainsKey("name"))
-                {
-                    SetNameRule();
-                }
-            }
+        #region Constructors
+
+        public CategoryDtoValidator(IHttpContextAccessor httpContextAccessor, IJsonHelper jsonHelper) : base(httpContextAccessor, jsonHelper)
+        {
+            SetNameRule();
         }
+
+        #endregion
+
+        #region Private Methods
 
         private void SetNameRule()
         {
-            RuleFor(x => x.Name)
-                        .NotNull()
-                        .NotEmpty()
-                        .WithMessage("name required");
+            SetNotNullOrEmptyCreateOrUpdateRule(c => c.Name, "invalid name", "name");
         }
+
+        #endregion
+
     }
 }

--- a/Nop.Plugin.Api/Validators/CategoryDtoValidator.cs
+++ b/Nop.Plugin.Api/Validators/CategoryDtoValidator.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.AspNetCore.Http;
 using Nop.Plugin.Api.DTOs.Categories;
 using Nop.Plugin.Api.Helpers;
+using System.Collections.Generic;
 
 namespace Nop.Plugin.Api.Validators
 {
@@ -9,7 +10,7 @@ namespace Nop.Plugin.Api.Validators
 
         #region Constructors
 
-        public CategoryDtoValidator(IHttpContextAccessor httpContextAccessor, IJsonHelper jsonHelper) : base(httpContextAccessor, jsonHelper)
+        public CategoryDtoValidator(IHttpContextAccessor httpContextAccessor, IJsonHelper jsonHelper, Dictionary<string, object> requestJsonDictionary) : base(httpContextAccessor, jsonHelper, requestJsonDictionary)
         {
             SetNameRule();
         }

--- a/Nop.Plugin.Api/Validators/CustomerDtoValidator.cs
+++ b/Nop.Plugin.Api/Validators/CustomerDtoValidator.cs
@@ -53,6 +53,13 @@ namespace Nop.Plugin.Api.Validators
                         var addressJsonDictionary = GetRequestJsonDictionaryCollectionItemDictionary(key, addressDto);
 
                         var validator = new AddressDtoValidator(HttpContextAccessor, JsonHelper, addressJsonDictionary);
+
+                        //force create validation for new addresses
+                        if (addressDto.Id == 0)
+                        {
+                            validator.HttpMethod = HttpMethod.Post;
+                        }
+
                         var validationResult = validator.Validate(addressDto);
 
                         MergeValidationResult(validationContext, validationResult);
@@ -144,6 +151,13 @@ namespace Nop.Plugin.Api.Validators
                         var shoppingCartItemJsonDictionary = GetRequestJsonDictionaryCollectionItemDictionary(key, shoppingCartItemDto);
 
                         var validator = new ShoppingCartItemDtoValidator(HttpContextAccessor, JsonHelper, shoppingCartItemJsonDictionary);
+
+                        //force create validation for new addresses
+                        if (shoppingCartItemDto.Id == 0)
+                        {
+                            validator.HttpMethod = HttpMethod.Post;
+                        }
+
                         var validationResult = validator.Validate(shoppingCartItemDto);
 
                         MergeValidationResult(validationContext, validationResult);

--- a/Nop.Plugin.Api/Validators/CustomerDtoValidator.cs
+++ b/Nop.Plugin.Api/Validators/CustomerDtoValidator.cs
@@ -47,7 +47,7 @@ namespace Nop.Plugin.Api.Validators
             var key = "addresses";
             if (RequestJsonDictionary.ContainsKey(key))
             {
-                RuleForEach(c => c.CustomerAddresses)
+                RuleForEach(c => c.Addresses)
                     .Custom((addressDto, validationContext) =>
                     {
                         var addressJsonDictionary = GetRequestJsonDictionaryCollectionItemDictionary(key, addressDto);

--- a/Nop.Plugin.Api/Validators/OrderDtoValidator.cs
+++ b/Nop.Plugin.Api/Validators/OrderDtoValidator.cs
@@ -1,40 +1,29 @@
-﻿using System;
-using System.Collections.Generic;
-using FluentValidation;
+﻿using Microsoft.AspNetCore.Http;
 using Nop.Plugin.Api.DTOs.Orders;
+using Nop.Plugin.Api.Helpers;
 
 namespace Nop.Plugin.Api.Validators
 {
-    public class OrderDtoValidator : AbstractValidator<OrderDto>
+    public class OrderDtoValidator : BaseDtoValidator<OrderDto>
     {
-        public OrderDtoValidator(string httpMethod, IReadOnlyDictionary<string, object> passedPropertyValuePaires)
-        {
-            if (string.IsNullOrEmpty(httpMethod) ||
-                httpMethod.Equals("post", StringComparison.InvariantCultureIgnoreCase))
-            {
-                SetCustomerIdRule();
-            }
-            else if(httpMethod.Equals("put", StringComparison.InvariantCultureIgnoreCase))
-            {
-                RuleFor(x => x.Id)
-                        .NotNull()
-                        .NotEmpty()
-                        .Must(id => int.TryParse(id, out var parsedId) && parsedId > 0)
-                        .WithMessage("Invalid id");
 
-                if (passedPropertyValuePaires.ContainsKey("customer_id"))
-                {
-                    SetCustomerIdRule();
-                }
-            }
+        #region Constructors
+
+        public OrderDtoValidator(IHttpContextAccessor httpContextAccessor, IJsonHelper jsonHelper) : base(httpContextAccessor, jsonHelper)
+        {
+            SetCustomerIdRule();
         }
+
+        #endregion
+
+        #region Private Methods
 
         private void SetCustomerIdRule()
         {
-            RuleFor(x => x.CustomerId)
-                      .NotNull()
-                      .Must(id => id > 0)
-                      .WithMessage("Invalid customer_id");
+            SetGreaterThanZeroCreateOrUpdateRule(o => o.CustomerId, "invalid customer_id", "customer_id");
         }
+
+        #endregion
+
     }
 }

--- a/Nop.Plugin.Api/Validators/OrderDtoValidator.cs
+++ b/Nop.Plugin.Api/Validators/OrderDtoValidator.cs
@@ -1,7 +1,9 @@
-﻿using Microsoft.AspNetCore.Http;
+﻿using FluentValidation;
+using Microsoft.AspNetCore.Http;
 using Nop.Plugin.Api.DTOs.Orders;
 using Nop.Plugin.Api.Helpers;
 using System.Collections.Generic;
+using System.Net.Http;
 
 namespace Nop.Plugin.Api.Validators
 {
@@ -13,6 +15,7 @@ namespace Nop.Plugin.Api.Validators
         public OrderDtoValidator(IHttpContextAccessor httpContextAccessor, IJsonHelper jsonHelper, Dictionary<string, object> requestJsonDictionary) : base(httpContextAccessor, jsonHelper, requestJsonDictionary)
         {
             SetCustomerIdRule();
+            SetOrderItemsRule();
         }
 
         #endregion
@@ -22,6 +25,30 @@ namespace Nop.Plugin.Api.Validators
         private void SetCustomerIdRule()
         {
             SetGreaterThanZeroCreateOrUpdateRule(o => o.CustomerId, "invalid customer_id", "customer_id");
+        }
+
+        private void SetOrderItemsRule()
+        {
+            var key = "order_items";
+            if (RequestJsonDictionary.ContainsKey(key))
+            {
+                RuleForEach(c => c.OrderItems)
+                    .Custom((orderItemDto, validationContext) =>
+                    {
+                        var orderItemJsonDictionary = GetRequestJsonDictionaryCollectionItemDictionary(key, orderItemDto);
+
+                        var validator = new OrderItemDtoValidator(HttpContextAccessor, JsonHelper, orderItemJsonDictionary);
+
+                        //force create validation for new addresses
+                        if (orderItemDto.Id == 0)
+                        {
+                            validator.HttpMethod = HttpMethod.Post;
+                        }
+
+                        var validationResult = validator.Validate(orderItemDto);
+                        MergeValidationResult(validationContext, validationResult);
+                    });
+            }
         }
 
         #endregion

--- a/Nop.Plugin.Api/Validators/OrderDtoValidator.cs
+++ b/Nop.Plugin.Api/Validators/OrderDtoValidator.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.AspNetCore.Http;
 using Nop.Plugin.Api.DTOs.Orders;
 using Nop.Plugin.Api.Helpers;
+using System.Collections.Generic;
 
 namespace Nop.Plugin.Api.Validators
 {
@@ -9,7 +10,7 @@ namespace Nop.Plugin.Api.Validators
 
         #region Constructors
 
-        public OrderDtoValidator(IHttpContextAccessor httpContextAccessor, IJsonHelper jsonHelper) : base(httpContextAccessor, jsonHelper)
+        public OrderDtoValidator(IHttpContextAccessor httpContextAccessor, IJsonHelper jsonHelper, Dictionary<string, object> requestJsonDictionary) : base(httpContextAccessor, jsonHelper, requestJsonDictionary)
         {
             SetCustomerIdRule();
         }

--- a/Nop.Plugin.Api/Validators/OrderItemDtoValidator.cs
+++ b/Nop.Plugin.Api/Validators/OrderItemDtoValidator.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.AspNetCore.Http;
 using Nop.Plugin.Api.DTOs.OrderItems;
 using Nop.Plugin.Api.Helpers;
+using System.Collections.Generic;
 
 namespace Nop.Plugin.Api.Validators
 {
@@ -9,9 +10,9 @@ namespace Nop.Plugin.Api.Validators
 
         #region Constructors
 
-        public OrderItemDtoValidator(IHttpContextAccessor httpContextAccessor, IJsonHelper jsonHelper) : base(httpContextAccessor, jsonHelper)
+        public OrderItemDtoValidator(IHttpContextAccessor httpContextAccessor, IJsonHelper jsonHelper, Dictionary<string, object> requestJsonDictionary) : base(httpContextAccessor, jsonHelper, requestJsonDictionary)
         {
-            SetProductRule();
+            SetProductIdRule();
             SetQuantityRule();
         }
 
@@ -19,7 +20,7 @@ namespace Nop.Plugin.Api.Validators
 
         #region Private Methods
 
-        private void SetProductRule()
+        private void SetProductIdRule()
         {
             SetGreaterThanZeroCreateOrUpdateRule(o => o.ProductId, "invalid product_id", "product_id");
         }

--- a/Nop.Plugin.Api/Validators/OrderItemDtoValidator.cs
+++ b/Nop.Plugin.Api/Validators/OrderItemDtoValidator.cs
@@ -1,47 +1,35 @@
-﻿using System;
-using System.Collections.Generic;
-using FluentValidation;
+﻿using Microsoft.AspNetCore.Http;
 using Nop.Plugin.Api.DTOs.OrderItems;
+using Nop.Plugin.Api.Helpers;
 
 namespace Nop.Plugin.Api.Validators
 {
-    public class OrderItemDtoValidator : AbstractValidator<OrderItemDto>
+    public class OrderItemDtoValidator : BaseDtoValidator<OrderItemDto>
     {
-        public OrderItemDtoValidator(string httpMethod, IReadOnlyDictionary<string, object> passedPropertyValuePaires)
-        {
-            if (string.IsNullOrEmpty(httpMethod) ||
-                httpMethod.Equals("post", StringComparison.InvariantCultureIgnoreCase))
-            {
-                SetProductRule();
-                SetQuantityRule();
-            }
-            else if (httpMethod.Equals("put", StringComparison.InvariantCultureIgnoreCase))
-            {
-                if (passedPropertyValuePaires.ContainsKey("product_id"))
-                {
-                    SetProductRule();
-                }
 
-                if (passedPropertyValuePaires.ContainsKey("quantity"))
-                {
-                    SetQuantityRule();
-                }
-            }
+        #region Constructors
+
+        public OrderItemDtoValidator(IHttpContextAccessor httpContextAccessor, IJsonHelper jsonHelper) : base(httpContextAccessor, jsonHelper)
+        {
+            SetProductRule();
+            SetQuantityRule();
         }
+
+        #endregion
+
+        #region Private Methods
 
         private void SetProductRule()
         {
-            RuleFor(x => x.ProductId)
-                    .NotNull()
-                    .WithMessage("Invalid product id");
+            SetGreaterThanZeroCreateOrUpdateRule(o => o.ProductId, "invalid product_id", "product_id");
         }
 
         private void SetQuantityRule()
         {
-            RuleFor(x => x.Quantity)
-                    .NotNull()
-                    .Must(quantity => quantity > 0)
-                    .WithMessage("Invalid quantity");
+            SetGreaterThanZeroCreateOrUpdateRule(o => o.Quantity, "invalid quanitty", "quantity");
         }
+
+        #endregion
+
     }
 }

--- a/Nop.Plugin.Api/Validators/ProductAttributeDtoValidator.cs
+++ b/Nop.Plugin.Api/Validators/ProductAttributeDtoValidator.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.AspNetCore.Http;
 using Nop.Plugin.Api.DTOs.ProductAttributes;
 using Nop.Plugin.Api.Helpers;
+using System.Collections.Generic;
 
 namespace Nop.Plugin.Api.Validators
 {
@@ -9,7 +10,7 @@ namespace Nop.Plugin.Api.Validators
 
         #region Constructors
 
-        public ProductAttributeDtoValidator(IHttpContextAccessor httpContextAccessor, IJsonHelper jsonHelper) : base(httpContextAccessor, jsonHelper)
+        public ProductAttributeDtoValidator(IHttpContextAccessor httpContextAccessor, IJsonHelper jsonHelper, Dictionary<string, object> requestJsonDictionary) : base(httpContextAccessor, jsonHelper, requestJsonDictionary)
         {
             SetNameRule();
         }

--- a/Nop.Plugin.Api/Validators/ProductAttributeDtoValidator.cs
+++ b/Nop.Plugin.Api/Validators/ProductAttributeDtoValidator.cs
@@ -1,39 +1,29 @@
-﻿using System;
-using System.Collections.Generic;
-using FluentValidation;
+﻿using Microsoft.AspNetCore.Http;
 using Nop.Plugin.Api.DTOs.ProductAttributes;
+using Nop.Plugin.Api.Helpers;
 
 namespace Nop.Plugin.Api.Validators
 {
-    public class ProductAttributeDtoValidator : AbstractValidator<ProductAttributeDto>
+    public class ProductAttributeDtoValidator : BaseDtoValidator<ProductAttributeDto>
     {
-        public ProductAttributeDtoValidator(string httpMethod, IReadOnlyDictionary<string, object> passedPropertyValuePaires)
-        {
-            if (string.IsNullOrEmpty(httpMethod) || httpMethod.Equals("post", StringComparison.InvariantCultureIgnoreCase))
-            {
-                SetNameRule();
-            }
-            else if (httpMethod.Equals("put", StringComparison.InvariantCultureIgnoreCase))
-            {
-                RuleFor(x => x.Id)
-                        .NotNull()
-                        .NotEmpty()
-                        .Must(id => int.TryParse(id, out var parsedId) && parsedId > 0)
-                        .WithMessage("invalid id");
 
-                if (passedPropertyValuePaires.ContainsKey("name"))
-                {
-                    SetNameRule();
-                }
-            }
+        #region Constructors
+
+        public ProductAttributeDtoValidator(IHttpContextAccessor httpContextAccessor, IJsonHelper jsonHelper) : base(httpContextAccessor, jsonHelper)
+        {
+            SetNameRule();
         }
+
+        #endregion
+
+        #region Private Methods
 
         private void SetNameRule()
         {
-            RuleFor(x => x.Name)
-                       .NotNull()
-                       .NotEmpty()
-                       .WithMessage("name is required");
+            SetNotNullOrEmptyCreateOrUpdateRule(p => p.Name, "invalid name", "name");
         }
+
+        #endregion
+
     }
 }

--- a/Nop.Plugin.Api/Validators/ProductCategoryMappingDtoValidator.cs
+++ b/Nop.Plugin.Api/Validators/ProductCategoryMappingDtoValidator.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.AspNetCore.Http;
 using Nop.Plugin.Api.DTOs.ProductCategoryMappings;
 using Nop.Plugin.Api.Helpers;
+using System.Collections.Generic;
 
 namespace Nop.Plugin.Api.Validators
 {
@@ -9,7 +10,7 @@ namespace Nop.Plugin.Api.Validators
 
         #region Constructors
 
-        public ProductCategoryMappingDtoValidator(IHttpContextAccessor httpContextAccessor, IJsonHelper jsonHelper) : base(httpContextAccessor, jsonHelper)
+        public ProductCategoryMappingDtoValidator(IHttpContextAccessor httpContextAccessor, IJsonHelper jsonHelper, Dictionary<string, object> requestJsonDictionary) : base(httpContextAccessor, jsonHelper, requestJsonDictionary)
         {
             SetCategoryIdRule();
             SetProductIdRule();

--- a/Nop.Plugin.Api/Validators/ProductCategoryMappingDtoValidator.cs
+++ b/Nop.Plugin.Api/Validators/ProductCategoryMappingDtoValidator.cs
@@ -1,48 +1,35 @@
-﻿using System;
-using System.Collections.Generic;
-using FluentValidation;
+﻿using Microsoft.AspNetCore.Http;
 using Nop.Plugin.Api.DTOs.ProductCategoryMappings;
+using Nop.Plugin.Api.Helpers;
 
 namespace Nop.Plugin.Api.Validators
 {
-    public class ProductCategoryMappingDtoValidator : AbstractValidator<ProductCategoryMappingDto>
+    public class ProductCategoryMappingDtoValidator : BaseDtoValidator<ProductCategoryMappingDto>
     {
-        public ProductCategoryMappingDtoValidator(string httpMethod, IReadOnlyDictionary<string, object> passedPropertyValuePaires)
+
+        #region Constructors
+
+        public ProductCategoryMappingDtoValidator(IHttpContextAccessor httpContextAccessor, IJsonHelper jsonHelper) : base(httpContextAccessor, jsonHelper)
         {
-            if (string.IsNullOrEmpty(httpMethod) || httpMethod.Equals("post", StringComparison.InvariantCultureIgnoreCase))
-            {
-                RuleFor(mapping => mapping.CategoryId)
-                    .Must(categoryId => categoryId > 0)
-                    .WithMessage("invalid category_id")
-                    .DependentRules(() =>
-                    {
-                        RuleFor(a => a.ProductId)
-                            .Must(productId => productId > 0)
-                            .WithMessage("invalid product_id");
-                    });
-            }
-            else if (httpMethod.Equals("put", StringComparison.InvariantCultureIgnoreCase))
-            {
-                RuleFor(mapping => mapping.Id)
-                    .NotNull()
-                    .NotEmpty()
-                    .Must(id => id > 0)
-                    .WithMessage("invalid id");
-
-                if (passedPropertyValuePaires.ContainsKey("category_id"))
-                {
-                    RuleFor(mapping => mapping.CategoryId)
-                        .Must(categoryId => categoryId > 0)
-                        .WithMessage("category_id invalid");
-                }
-
-                if (passedPropertyValuePaires.ContainsKey("product_id"))
-                {
-                    RuleFor(mapping => mapping.ProductId)
-                        .Must(productId => productId > 0)
-                        .WithMessage("product_id invalid");
-                }
-            }
+            SetCategoryIdRule();
+            SetProductIdRule();
         }
+
+        #endregion
+
+        #region Private Methods
+
+        private void SetCategoryIdRule()
+        {
+            SetGreaterThanZeroCreateOrUpdateRule(p => p.CategoryId, "invalid category_id", "category_id");
+        }
+
+        private void SetProductIdRule()
+        {
+            SetGreaterThanZeroCreateOrUpdateRule(p => p.ProductId, "invalid product_id", "product_id");
+        }
+
+        #endregion
+
     }
 }

--- a/Nop.Plugin.Api/Validators/ProductDtoValidator.cs
+++ b/Nop.Plugin.Api/Validators/ProductDtoValidator.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.AspNetCore.Http;
 using Nop.Plugin.Api.DTOs.Products;
 using Nop.Plugin.Api.Helpers;
+using System.Collections.Generic;
 
 namespace Nop.Plugin.Api.Validators
 {
@@ -9,7 +10,7 @@ namespace Nop.Plugin.Api.Validators
 
         #region Constructors
 
-        public ProductDtoValidator(IHttpContextAccessor httpContextAccessor, IJsonHelper jsonHelper) : base(httpContextAccessor, jsonHelper)
+        public ProductDtoValidator(IHttpContextAccessor httpContextAccessor, IJsonHelper jsonHelper, Dictionary<string, object> requestJsonDictionary) : base(httpContextAccessor, jsonHelper, requestJsonDictionary)
         {
             SetNameRule();
         }

--- a/Nop.Plugin.Api/Validators/ProductDtoValidator.cs
+++ b/Nop.Plugin.Api/Validators/ProductDtoValidator.cs
@@ -1,5 +1,4 @@
-﻿using FluentValidation;
-using Microsoft.AspNetCore.Http;
+﻿using Microsoft.AspNetCore.Http;
 using Nop.Plugin.Api.DTOs.Products;
 using Nop.Plugin.Api.Helpers;
 
@@ -7,28 +6,24 @@ namespace Nop.Plugin.Api.Validators
 {
     public class ProductDtoValidator : BaseDtoValidator<ProductDto>
     {
+
+        #region Constructors
+
         public ProductDtoValidator(IHttpContextAccessor httpContextAccessor, IJsonHelper jsonHelper) : base(httpContextAccessor, jsonHelper)
         {
-            if (HttpMethods.IsPost(httpContextAccessor.HttpContext.Request.Method))
-            {
-                SetNameRule(false);
-            }
-            else if (HttpMethods.IsPut(httpContextAccessor.HttpContext.Request.Method))
-            {
-                SetRequiredIdRule();
-                SetNameRule(true);
-            }
+            SetNameRule();
         }
 
-        private void SetNameRule(bool isJsonValueRequiredForValidation)
+        #endregion
+
+        #region Private Methods
+
+        private void SetNameRule()
         {
-            if (!isJsonValueRequiredForValidation || JsonDictionary.ContainsKey("name"))
-            {
-                RuleFor(x => x.Name)
-                           .NotNull()
-                           .NotEmpty()
-                           .WithMessage("name is required");
-            }
+            SetNotNullOrEmptyCreateOrUpdateRule(p => p.Name, "invalid name", "name");
         }
+
+        #endregion
+
     }
 }

--- a/Nop.Plugin.Api/Validators/ShoppingCartItemDtoValidator.cs
+++ b/Nop.Plugin.Api/Validators/ShoppingCartItemDtoValidator.cs
@@ -1,55 +1,50 @@
-﻿using System;
-using System.Collections.Generic;
-using FluentValidation;
+﻿using FluentValidation;
+using Microsoft.AspNetCore.Http;
 using Nop.Core.Domain.Orders;
 using Nop.Plugin.Api.DTOs.ShoppingCarts;
+using Nop.Plugin.Api.Helpers;
+using System;
+using System.Net.Http;
 
 namespace Nop.Plugin.Api.Validators
 {
-    public class ShoppingCartItemDtoValidator : AbstractValidator<ShoppingCartItemDto>
+    public class ShoppingCartItemDtoValidator : BaseDtoValidator<ShoppingCartItemDto>
     {
-        public ShoppingCartItemDtoValidator(string httpMethod, IReadOnlyDictionary<string, object> passedPropertyValuePaires)
+
+        #region Constructors
+
+        public ShoppingCartItemDtoValidator(IHttpContextAccessor httpContextAccessor, IJsonHelper jsonHelper) : base(httpContextAccessor, jsonHelper)
         {
-            if (string.IsNullOrEmpty(httpMethod) || httpMethod.Equals("post", StringComparison.InvariantCultureIgnoreCase))
-            {
-                SetCustomerIdRule();
+            SetCustomerIdRule();
+            SetProductIdRule();
+            SetQuantityRule();
+            SetShoppingCartTypeRule();
 
-                SetProductIdRule();
+            SetRentalDateRules();
+        }
 
-                SetQuantityRule();
-                
-                ValidateShoppingCartType();
-            }
-            else if (httpMethod.Equals("put", StringComparison.InvariantCultureIgnoreCase))
-            {
-                RuleFor(x => x.Id)
-                        .NotNull()
-                        .NotEmpty()
-                        .Must(id => int.TryParse(id, out var parsedId) && parsedId > 0)
-                        .WithMessage("Invalid Id");
+        #endregion
 
-                if (passedPropertyValuePaires.ContainsKey("customer_id"))
-                {
-                    SetCustomerIdRule();
-                }
+        #region Private Methods
 
-                if (passedPropertyValuePaires.ContainsKey("product_id"))
-                {
-                    SetProductIdRule();
-                }
+        private void SetCustomerIdRule()
+        {
+            SetGreaterThanZeroCreateOrUpdateRule(x => x.CustomerId, "invalid customer_id", "customer_id");
+        }
 
-                if (passedPropertyValuePaires.ContainsKey("quantity"))
-                {
-                    SetQuantityRule();
-                }
+        private void SetProductIdRule()
+        {
+            SetGreaterThanZeroCreateOrUpdateRule(x => x.ProductId, "invalid product_id", "product_id");
+        }
 
-                if (passedPropertyValuePaires.ContainsKey("shopping_cart_type"))
-                {
-                    ValidateShoppingCartType();
-                }
-            }
+        private void SetQuantityRule()
+        {
+            SetGreaterThanZeroCreateOrUpdateRule(x => x.Quantity, "invalid quantity", "quantity");
+        }
 
-            if (passedPropertyValuePaires.ContainsKey("rental_start_date_utc") || passedPropertyValuePaires.ContainsKey("rental_end_date_utc"))
+        private void SetRentalDateRules()
+        {
+            if (JsonDictionary.ContainsKey("rental_start_date_utc") || JsonDictionary.ContainsKey("rental_end_date_utc"))
             {
                 RuleFor(x => x.RentalStartDateUtc)
                     .NotNull()
@@ -73,37 +68,22 @@ namespace Nop.Plugin.Api.Validators
             }
         }
 
-        private void SetCustomerIdRule()
+        private void SetShoppingCartTypeRule()
         {
-            RuleFor(x => x.CustomerId)
-                   .NotNull()
-                   .WithMessage("Please, set customer id");
+            if (HttpMethod == HttpMethod.Post || JsonDictionary.ContainsKey("shopping_cart_type"))
+            {
+                RuleFor(x => x.ShoppingCartType)
+                    .NotNull()
+                    .Must(x =>
+                    {
+                        var parsed = Enum.TryParse(x, true, out ShoppingCartType _);
+                        return parsed;
+                    })
+                    .WithMessage("Please provide a valid shopping cart type");
+            }
         }
 
-        private void SetProductIdRule()
-        {
-            RuleFor(x => x.ProductId)
-                   .NotNull()
-                   .WithMessage("Please, set product id");
-        }
+        #endregion
 
-        private void SetQuantityRule()
-        {
-            RuleFor(x => x.Quantity)
-                      .NotNull()
-                      .WithMessage("Please, set quantity");
-        }
-
-        private void ValidateShoppingCartType()
-        {
-            RuleFor(x => x.ShoppingCartType)
-                .NotNull()
-                .Must(x =>
-                {
-                    var parsed = Enum.TryParse(x, true, out ShoppingCartType _);
-                    return parsed;
-                })
-                .WithMessage("Please provide a valid shopping cart type");
-        }
     }
 }

--- a/Nop.Plugin.Api/Validators/ShoppingCartItemDtoValidator.cs
+++ b/Nop.Plugin.Api/Validators/ShoppingCartItemDtoValidator.cs
@@ -4,6 +4,7 @@ using Nop.Core.Domain.Orders;
 using Nop.Plugin.Api.DTOs.ShoppingCarts;
 using Nop.Plugin.Api.Helpers;
 using System;
+using System.Collections.Generic;
 using System.Net.Http;
 
 namespace Nop.Plugin.Api.Validators
@@ -13,7 +14,7 @@ namespace Nop.Plugin.Api.Validators
 
         #region Constructors
 
-        public ShoppingCartItemDtoValidator(IHttpContextAccessor httpContextAccessor, IJsonHelper jsonHelper) : base(httpContextAccessor, jsonHelper)
+        public ShoppingCartItemDtoValidator(IHttpContextAccessor httpContextAccessor, IJsonHelper jsonHelper, Dictionary<string, object> requestJsonDictionary) : base(httpContextAccessor, jsonHelper, requestJsonDictionary)
         {
             SetCustomerIdRule();
             SetProductIdRule();
@@ -44,7 +45,7 @@ namespace Nop.Plugin.Api.Validators
 
         private void SetRentalDateRules()
         {
-            if (JsonDictionary.ContainsKey("rental_start_date_utc") || JsonDictionary.ContainsKey("rental_end_date_utc"))
+            if (RequestJsonDictionary.ContainsKey("rental_start_date_utc") || RequestJsonDictionary.ContainsKey("rental_end_date_utc"))
             {
                 RuleFor(x => x.RentalStartDateUtc)
                     .NotNull()
@@ -70,7 +71,7 @@ namespace Nop.Plugin.Api.Validators
 
         private void SetShoppingCartTypeRule()
         {
-            if (HttpMethod == HttpMethod.Post || JsonDictionary.ContainsKey("shopping_cart_type"))
+            if (HttpMethod == HttpMethod.Post || RequestJsonDictionary.ContainsKey("shopping_cart_type"))
             {
                 RuleFor(x => x.ShoppingCartType)
                     .NotNull()


### PR DESCRIPTION
This PR fixes addresses a number of issues present with Nop 4.1.

- Fixes PUT/POST calls.  The validators were throwing errors before when trying to resolve their dependencies (constructor params).  This is because FluentValidation now supports validating child objects automatically, so when it tried to resolve the child object validators, it could not resolve the constructor parameters (HttpMethod and a dictionary of the passed-in JSON key/value pairs).  This PR refactors the validators so they can be resolved by DI.

- Removes validator calls from `JsonModelBinder`.  The model binder was explicitly validating the`Model.Dto`.  This is because FluentValidation did not support validation child objects.  `JsonModelBinder` has been refactored to NOT call any `Validate()` methods (validation runs before the model binder)

- Adds/fixes validation for `CustomerDto.Addresses`, `CustomerDto.ShoppingCartItems`, and `OrderDto.OrderItems`.  Some of this validation was completely missing before, and some was manually being done at the controller level.  Now, all validation is handled inside the validators -- the controllers should not need to manually validate any child objects.

- Standardizes some property names.  For example, `CustomerDto.CustomerAddresses` is now `CustomerDto.Addresses`.  This was done simply to match the property names of the Nop entities.

There may be a few more fixes, and possibly some new bugs (hopefully not).  I've done what I can to test the various API calls, but there are a lot of potential scenarios, so I can't guarantee 100% coverage.