### PR TITLE
Product API Enhancements, Order API Bugfix

### DIFF
--- a/Nop.Plugin.Api/Controllers/CustomersController.cs
+++ b/Nop.Plugin.Api/Controllers/CustomersController.cs
@@ -308,34 +308,6 @@ namespace Nop.Plugin.Api.Controllers
             return new RawJsonActionResult(json);
         }
 
-        /// <summary>
-        /// Retrieve customer by spcified id
-        /// </summary>
-        /// <param name="id">Id of the customer</param>
-        /// <param name="fields">Fields from the customer you want your json to contain</param>
-        /// <response code="200">OK</response>
-        /// <response code="404">Not Found</response>
-        /// <response code="401">Unauthorized</response>
-        [HttpGet]
-        [Route("/api/customers/guest")]
-        [ProducesResponseType(typeof(CustomersRootObject), (int)HttpStatusCode.OK)]
-        [ProducesResponseType(typeof(ErrorsRootObject), (int)HttpStatusCode.BadRequest)]
-        [ProducesResponseType(typeof(string), (int)HttpStatusCode.NotFound)]
-        [ProducesResponseType(typeof(string), (int)HttpStatusCode.Unauthorized)]
-        [GetRequestsErrorInterceptorActionFilter]
-        public IActionResult CreateGuestCustomer()
-        {
-            var customer = CustomerService.InsertGuestCustomer();
-            var customerDto = customer.ToDto();
-
-            var customersRootObject = new CustomersRootObject();
-            customersRootObject.Customers.Add(customerDto);
-
-            var json = JsonFieldsSerializer.Serialize(customersRootObject, string.Empty);
-
-            return new RawJsonActionResult(json);
-        }
-
         [HttpPut]
         [Route("/api/customers/{id}")]
         [ProducesResponseType(typeof(CustomersRootObject), (int)HttpStatusCode.OK)]

--- a/Nop.Plugin.Api/Controllers/CustomersController.cs
+++ b/Nop.Plugin.Api/Controllers/CustomersController.cs
@@ -307,7 +307,35 @@ namespace Nop.Plugin.Api.Controllers
 
             return new RawJsonActionResult(json);
         }
-        
+
+        /// <summary>
+        /// Retrieve customer by spcified id
+        /// </summary>
+        /// <param name="id">Id of the customer</param>
+        /// <param name="fields">Fields from the customer you want your json to contain</param>
+        /// <response code="200">OK</response>
+        /// <response code="404">Not Found</response>
+        /// <response code="401">Unauthorized</response>
+        [HttpGet]
+        [Route("/api/customers/guest")]
+        [ProducesResponseType(typeof(CustomersRootObject), (int)HttpStatusCode.OK)]
+        [ProducesResponseType(typeof(ErrorsRootObject), (int)HttpStatusCode.BadRequest)]
+        [ProducesResponseType(typeof(string), (int)HttpStatusCode.NotFound)]
+        [ProducesResponseType(typeof(string), (int)HttpStatusCode.Unauthorized)]
+        [GetRequestsErrorInterceptorActionFilter]
+        public IActionResult CreateGuestCustomer()
+        {
+            var customer = CustomerService.InsertGuestCustomer();
+            var customerDto = customer.ToDto();
+
+            var customersRootObject = new CustomersRootObject();
+            customersRootObject.Customers.Add(customerDto);
+
+            var json = JsonFieldsSerializer.Serialize(customersRootObject, string.Empty);
+
+            return new RawJsonActionResult(json);
+        }
+
         [HttpPut]
         [Route("/api/customers/{id}")]
         [ProducesResponseType(typeof(CustomersRootObject), (int)HttpStatusCode.OK)]

--- a/Nop.Plugin.Api/Controllers/OrdersController.cs
+++ b/Nop.Plugin.Api/Controllers/OrdersController.cs
@@ -212,7 +212,7 @@ namespace Nop.Plugin.Api.Controllers
         /// <response code="200">OK</response>
         /// <response code="401">Unauthorized</response>
         [HttpGet]
-        [Route("/api/orders/customer/{customer_id}")]
+        [Route("/api/orders/customer/{customerId}")]
         [ProducesResponseType(typeof(OrdersRootObject), (int)HttpStatusCode.OK)]
         [ProducesResponseType(typeof(string), (int)HttpStatusCode.Unauthorized)]
         [GetRequestsErrorInterceptorActionFilter]

--- a/Nop.Plugin.Api/Controllers/OrdersController.cs
+++ b/Nop.Plugin.Api/Controllers/OrdersController.cs
@@ -634,17 +634,15 @@ namespace Nop.Plugin.Api.Controllers
 
                     var errors = new List<string>();
 
-                    if (existingItem != null && orderItem.Quantity.HasValue && existingItem.Quantity != orderItem.Quantity)
+                   if (existingItem != null)
                     {
-                        existingItem.Quantity = orderItem.Quantity.Value;
-
-                        errors.AddRange(_shoppingCartService.UpdateShoppingCartItem(
-                            customer,
-                            existingItem.Id,
-                            existingItem.AttributesXml,
-                            existingItem.CustomerEnteredPrice,
-                            existingItem.RentalStartDateUtc,
-                            existingItem.RentalEndDateUtc));
+                        if (orderItem.Quantity.HasValue 
+                            && existingItem.Quantity != orderItem.Quantity)
+                        {
+                            existingItem.Quantity = orderItem.Quantity.Value;
+                                existingItem.RentalStartDateUtc,
+                                existingItem.RentalEndDateUtc));
+                        }
                     }
                     else
                     {

--- a/Nop.Plugin.Api/Controllers/OrdersController.cs
+++ b/Nop.Plugin.Api/Controllers/OrdersController.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;
@@ -49,10 +49,10 @@ namespace Nop.Plugin.Api.Controllers
         private readonly IShoppingCartService _shoppingCartService;
         private readonly IGenericAttributeService _genericAttributeService;
         private readonly IShippingService _shippingService;
-        private readonly IDTOHelper _dtoHelper;        
-        private readonly IProductAttributeConverter _productAttributeConverter;
+        private readonly IDTOHelper _dtoHelper;
         private readonly IStoreContext _storeContext;
         private readonly IFactory<Order> _factory;
+        private readonly IEncryptionService _encryptionService;
 
         // We resolve the order settings this way because of the tests.
         // The auto mocking does not support concreate types as dependencies. It supports only interfaces.
@@ -78,10 +78,10 @@ namespace Nop.Plugin.Api.Controllers
             IStoreContext storeContext,
             IShippingService shippingService,
             IPictureService pictureService,
-            IDTOHelper dtoHelper,
-            IProductAttributeConverter productAttributeConverter)
+            IEncryptionService encryptionService,
+            IDTOHelper dtoHelper)
             : base(jsonFieldsSerializer, aclService, customerService, storeMappingService,
-                 storeService, discountService, customerActivityService, localizationService,pictureService)
+                 storeService, discountService, customerActivityService, localizationService, pictureService)
         {
             _orderApiService = orderApiService;
             _factory = factory;
@@ -93,7 +93,7 @@ namespace Nop.Plugin.Api.Controllers
             _shippingService = shippingService;
             _dtoHelper = dtoHelper;
             _productService = productService;
-            _productAttributeConverter = productAttributeConverter;
+            _encryptionService = encryptionService;
         }
 
         /// <summary>
@@ -197,6 +197,12 @@ namespace Nop.Plugin.Api.Controllers
 
             var ordersRootObject = new OrdersRootObject();
 
+            string decryptedCardNumber = _encryptionService.DecryptText(order.MaskedCreditCardNumber);
+            if (!string.IsNullOrWhiteSpace(decryptedCardNumber))
+            {
+                order.CardNumber = decryptedCardNumber;
+            }
+
             var orderDto = _dtoHelper.PrepareOrderDTO(order);
             ordersRootObject.Orders.Add(orderDto);
 
@@ -212,7 +218,7 @@ namespace Nop.Plugin.Api.Controllers
         /// <response code="200">OK</response>
         /// <response code="401">Unauthorized</response>
         [HttpGet]
-        [Route("/api/orders/customer/{customerId}")]
+        [Route("/api/orders/customer/{customerid}")]
         [ProducesResponseType(typeof(OrdersRootObject), (int)HttpStatusCode.OK)]
         [ProducesResponseType(typeof(string), (int)HttpStatusCode.Unauthorized)]
         [GetRequestsErrorInterceptorActionFilter]
@@ -250,7 +256,7 @@ namespace Nop.Plugin.Api.Controllers
 
             // We doesn't have to check for value because this is done by the order validator.
             var customer = CustomerService.GetCustomerById(orderDelta.Dto.CustomerId.Value);
-            
+
             if (customer == null)
             {
                 return Error(HttpStatusCode.NotFound, "customer", "not found");
@@ -276,9 +282,9 @@ namespace Nop.Plugin.Api.Controllers
                 isValid &= SetShippingOption(orderDelta.Dto.ShippingRateComputationMethodSystemName,
                                             orderDelta.Dto.ShippingMethod,
                                             orderDelta.Dto.StoreId ?? _storeContext.CurrentStore.Id,
-                                            customer, 
-                                            BuildShoppingCartItemsFromOrderItemDtos(orderDelta.Dto.OrderItems.ToList(), 
-                                                                                    customer.Id, 
+                                            customer,
+                                            BuildShoppingCartItemsFromOrderItemDtos(orderDelta.Dto.OrderItems.ToList(),
+                                                                                    customer.Id,
                                                                                     orderDelta.Dto.StoreId ?? _storeContext.CurrentStore.Id));
 
                 if (!isValid)
@@ -290,8 +296,11 @@ namespace Nop.Plugin.Api.Controllers
             var newOrder = _factory.Initialize();
             orderDelta.Merge(newOrder);
 
-            customer.BillingAddress = newOrder.BillingAddress;
-            customer.ShippingAddress = newOrder.ShippingAddress;
+            if (newOrder.BillingAddress != null)
+                customer.BillingAddressId = newOrder.BillingAddress.Id;
+            if (newOrder.ShippingAddress != null)
+                customer.ShippingAddressId = newOrder.ShippingAddress.Id;
+            CustomerService.UpdateCustomer(customer);
 
             // If the customer has something in the cart it will be added too. Should we clear the cart first? 
             newOrder.Customer = customer;
@@ -301,7 +310,7 @@ namespace Nop.Plugin.Api.Controllers
             {
                 newOrder.StoreId = _storeContext.CurrentStore.Id;
             }
-            
+
             var placeOrderResult = PlaceOrder(newOrder, customer);
 
             if (!placeOrderResult.Success)
@@ -342,7 +351,7 @@ namespace Nop.Plugin.Api.Controllers
             {
                 return Error(HttpStatusCode.BadRequest, "id", "invalid id");
             }
-            
+
             var orderToDelete = _orderApiService.GetOrderById(id);
 
             if (orderToDelete == null)
@@ -394,7 +403,7 @@ namespace Nop.Plugin.Api.Controllers
                     var storeId = orderDelta.Dto.StoreId ?? _storeContext.CurrentStore.Id;
 
                     isValid &= SetShippingOption(orderDelta.Dto.ShippingRateComputationMethodSystemName ?? currentOrder.ShippingRateComputationMethodSystemName,
-                        orderDelta.Dto.ShippingMethod, 
+                        orderDelta.Dto.ShippingMethod,
                         storeId,
                         customer, BuildShoppingCartItemsFromOrderItems(currentOrder.OrderItems.ToList(), customer.Id, storeId));
                 }
@@ -410,7 +419,7 @@ namespace Nop.Plugin.Api.Controllers
             }
 
             orderDelta.Merge(currentOrder);
-            
+
             customer.BillingAddress = currentOrder.BillingAddress;
             customer.ShippingAddress = currentOrder.ShippingAddress;
 
@@ -459,7 +468,7 @@ namespace Nop.Plugin.Api.Controllers
 
                     var shippingOption = shippingOptions
                         .Find(so => !string.IsNullOrEmpty(so.Name) && so.Name.Equals(shippingOptionName, StringComparison.InvariantCultureIgnoreCase));
-                    
+
                     _genericAttributeService.SaveAttribute(customer,
                         NopCustomerDefaults.SelectedShippingOptionAttribute,
                         shippingOption, storeId);
@@ -527,11 +536,22 @@ namespace Nop.Plugin.Api.Controllers
 
         private PlaceOrderResult PlaceOrder(Order newOrder, Customer customer)
         {
+            int cardExpirationMonth = 0;
+            int cardExpirationYear = 0;
+            int.TryParse(newOrder.CardExpirationMonth, out cardExpirationMonth);
+            int.TryParse(newOrder.CardExpirationYear, out cardExpirationYear);
+
             var processPaymentRequest = new ProcessPaymentRequest
             {
                 StoreId = newOrder.StoreId,
                 CustomerId = customer.Id,
-                PaymentMethodSystemName = newOrder.PaymentMethodSystemName
+                PaymentMethodSystemName = newOrder.PaymentMethodSystemName,
+                CreditCardName = newOrder.CardName,
+                CreditCardNumber = newOrder.CardNumber,
+                CreditCardType = newOrder.CardType,
+                CreditCardExpireMonth = cardExpirationMonth,
+                CreditCardExpireYear = cardExpirationYear,
+                CreditCardCvv2 = newOrder.CardCvv2,
             };
 
 
@@ -573,12 +593,36 @@ namespace Nop.Plugin.Api.Controllers
                         orderItem.RentalEndDateUtc = null;
                     }
 
-                    var attributesXml = _productAttributeConverter.ConvertToXml(orderItem.Attributes.ToList(), product.Id);                
+                    var existingItem = _shoppingCartService.FindShoppingCartItemInTheCart(
+                                                                                    customer.ShoppingCartItems.ToList(),
+                                                                                    ShoppingCartType.ShoppingCart,
+                                                                                    product,
+                                                                                    orderItem.AttributesXml,
+                                                                                    orderItem.UnitPriceExclTax.HasValue ? orderItem.UnitPriceExclTax.Value : 0M,
+                                                                                    orderItem.RentalStartDateUtc,
+                                                                                    orderItem.RentalEndDateUtc);
 
-                    var errors = _shoppingCartService.AddToCart(customer, product,
-                        ShoppingCartType.ShoppingCart, storeId,attributesXml,
-                        0M, orderItem.RentalStartDateUtc, orderItem.RentalEndDateUtc,
-                        orderItem.Quantity ?? 1);
+                    var errors = new List<string>();
+
+                    if (existingItem != null && orderItem.Quantity.HasValue && existingItem.Quantity != orderItem.Quantity)
+                    {
+                        existingItem.Quantity = orderItem.Quantity.Value;
+
+                        errors.AddRange(_shoppingCartService.UpdateShoppingCartItem(
+                            customer,
+                            existingItem.Id,
+                            existingItem.AttributesXml,
+                            existingItem.CustomerEnteredPrice,
+                            existingItem.RentalStartDateUtc,
+                            existingItem.RentalEndDateUtc));
+                    }
+                    else
+                    {
+                        errors.AddRange(_shoppingCartService.AddToCart(customer, product,
+                            ShoppingCartType.ShoppingCart, storeId, orderItem.AttributesXml,
+                            0M, orderItem.RentalStartDateUtc, orderItem.RentalEndDateUtc,
+                            orderItem.Quantity ?? 1));
+                    }
 
                     if (errors.Count > 0)
                     {
@@ -594,5 +638,5 @@ namespace Nop.Plugin.Api.Controllers
 
             return shouldReturnError;
         }
-     }
+    }
 }

--- a/Nop.Plugin.Api/Controllers/OrdersController.cs
+++ b/Nop.Plugin.Api/Controllers/OrdersController.cs
@@ -49,10 +49,10 @@ namespace Nop.Plugin.Api.Controllers
         private readonly IShoppingCartService _shoppingCartService;
         private readonly IGenericAttributeService _genericAttributeService;
         private readonly IShippingService _shippingService;
-        private readonly IDTOHelper _dtoHelper;        
-        private readonly IProductAttributeConverter _productAttributeConverter;
+        private readonly IDTOHelper _dtoHelper;
         private readonly IStoreContext _storeContext;
         private readonly IFactory<Order> _factory;
+        private readonly IEncryptionService _encryptionService;
 
         // We resolve the order settings this way because of the tests.
         // The auto mocking does not support concreate types as dependencies. It supports only interfaces.
@@ -78,10 +78,10 @@ namespace Nop.Plugin.Api.Controllers
             IStoreContext storeContext,
             IShippingService shippingService,
             IPictureService pictureService,
-            IDTOHelper dtoHelper,
-            IProductAttributeConverter productAttributeConverter)
+            IEncryptionService encryptionService,
+            IDTOHelper dtoHelper)
             : base(jsonFieldsSerializer, aclService, customerService, storeMappingService,
-                 storeService, discountService, customerActivityService, localizationService,pictureService)
+                 storeService, discountService, customerActivityService, localizationService, pictureService)
         {
             _orderApiService = orderApiService;
             _factory = factory;
@@ -93,7 +93,7 @@ namespace Nop.Plugin.Api.Controllers
             _shippingService = shippingService;
             _dtoHelper = dtoHelper;
             _productService = productService;
-            _productAttributeConverter = productAttributeConverter;
+            _encryptionService = encryptionService;
         }
 
         /// <summary>
@@ -197,6 +197,12 @@ namespace Nop.Plugin.Api.Controllers
 
             var ordersRootObject = new OrdersRootObject();
 
+            string decryptedCardNumber = _encryptionService.DecryptText(order.MaskedCreditCardNumber);
+            if (!string.IsNullOrWhiteSpace(decryptedCardNumber))
+            {
+                order.CardNumber = decryptedCardNumber;
+            }
+
             var orderDto = _dtoHelper.PrepareOrderDTO(order);
             ordersRootObject.Orders.Add(orderDto);
 
@@ -212,7 +218,7 @@ namespace Nop.Plugin.Api.Controllers
         /// <response code="200">OK</response>
         /// <response code="401">Unauthorized</response>
         [HttpGet]
-        [Route("/api/orders/customer/{customer_id}")]
+        [Route("/api/orders/customer/{customerid}")]
         [ProducesResponseType(typeof(OrdersRootObject), (int)HttpStatusCode.OK)]
         [ProducesResponseType(typeof(string), (int)HttpStatusCode.Unauthorized)]
         [GetRequestsErrorInterceptorActionFilter]
@@ -250,7 +256,7 @@ namespace Nop.Plugin.Api.Controllers
 
             // We doesn't have to check for value because this is done by the order validator.
             var customer = CustomerService.GetCustomerById(orderDelta.Dto.CustomerId.Value);
-            
+
             if (customer == null)
             {
                 return Error(HttpStatusCode.NotFound, "customer", "not found");
@@ -276,9 +282,9 @@ namespace Nop.Plugin.Api.Controllers
                 isValid &= SetShippingOption(orderDelta.Dto.ShippingRateComputationMethodSystemName,
                                             orderDelta.Dto.ShippingMethod,
                                             orderDelta.Dto.StoreId ?? _storeContext.CurrentStore.Id,
-                                            customer, 
-                                            BuildShoppingCartItemsFromOrderItemDtos(orderDelta.Dto.OrderItems.ToList(), 
-                                                                                    customer.Id, 
+                                            customer,
+                                            BuildShoppingCartItemsFromOrderItemDtos(orderDelta.Dto.OrderItems.ToList(),
+                                                                                    customer.Id,
                                                                                     orderDelta.Dto.StoreId ?? _storeContext.CurrentStore.Id));
 
                 if (!isValid)
@@ -290,8 +296,11 @@ namespace Nop.Plugin.Api.Controllers
             var newOrder = _factory.Initialize();
             orderDelta.Merge(newOrder);
 
-            customer.BillingAddress = newOrder.BillingAddress;
-            customer.ShippingAddress = newOrder.ShippingAddress;
+            if (newOrder.BillingAddress != null)
+                customer.BillingAddressId = newOrder.BillingAddress.Id;
+            if (newOrder.ShippingAddress != null)
+                customer.ShippingAddressId = newOrder.ShippingAddress.Id;
+            CustomerService.UpdateCustomer(customer);
 
             // If the customer has something in the cart it will be added too. Should we clear the cart first? 
             newOrder.Customer = customer;
@@ -301,7 +310,7 @@ namespace Nop.Plugin.Api.Controllers
             {
                 newOrder.StoreId = _storeContext.CurrentStore.Id;
             }
-            
+
             var placeOrderResult = PlaceOrder(newOrder, customer);
 
             if (!placeOrderResult.Success)
@@ -342,7 +351,7 @@ namespace Nop.Plugin.Api.Controllers
             {
                 return Error(HttpStatusCode.BadRequest, "id", "invalid id");
             }
-            
+
             var orderToDelete = _orderApiService.GetOrderById(id);
 
             if (orderToDelete == null)
@@ -394,7 +403,7 @@ namespace Nop.Plugin.Api.Controllers
                     var storeId = orderDelta.Dto.StoreId ?? _storeContext.CurrentStore.Id;
 
                     isValid &= SetShippingOption(orderDelta.Dto.ShippingRateComputationMethodSystemName ?? currentOrder.ShippingRateComputationMethodSystemName,
-                        orderDelta.Dto.ShippingMethod, 
+                        orderDelta.Dto.ShippingMethod,
                         storeId,
                         customer, BuildShoppingCartItemsFromOrderItems(currentOrder.OrderItems.ToList(), customer.Id, storeId));
                 }
@@ -410,7 +419,7 @@ namespace Nop.Plugin.Api.Controllers
             }
 
             orderDelta.Merge(currentOrder);
-            
+
             customer.BillingAddress = currentOrder.BillingAddress;
             customer.ShippingAddress = currentOrder.ShippingAddress;
 
@@ -427,6 +436,43 @@ namespace Nop.Plugin.Api.Controllers
             ordersRootObject.Orders.Add(placedOrderDto);
 
             var json = JsonFieldsSerializer.Serialize(ordersRootObject, string.Empty);
+
+            return new RawJsonActionResult(json);
+        }
+
+        [HttpGet]
+        [Route("/api/order/{orderGuid}")]
+        [ProducesResponseType(typeof(OrdersRootObject), (int)HttpStatusCode.OK)]
+        [ProducesResponseType(typeof(string), (int)HttpStatusCode.Unauthorized)]
+        [ProducesResponseType(typeof(ErrorsRootObject), (int)HttpStatusCode.BadRequest)]
+        [ProducesResponseType(typeof(string), (int)HttpStatusCode.NotFound)]
+        [GetRequestsErrorInterceptorActionFilter]
+        public IActionResult GetOrderByOrderGuid(string orderGuid, string fields = "")
+        {
+            if (string.IsNullOrWhiteSpace(orderGuid))
+            {
+                return Error(HttpStatusCode.BadRequest, "orderGuid", "orderGuid");
+            }
+
+            var order = _orderApiService.GetOrderByOrderGuid(orderGuid);
+
+            if (order == null)
+            {
+                return Error(HttpStatusCode.NotFound, "order", "not found");
+            }
+
+            var ordersRootObject = new OrdersRootObject();
+
+            string decryptedCardNumber = _encryptionService.DecryptText(order.MaskedCreditCardNumber);
+            if (!string.IsNullOrWhiteSpace(decryptedCardNumber))
+            {
+                order.CardNumber = decryptedCardNumber;
+            }
+
+            var orderDto = _dtoHelper.PrepareOrderDTO(order);
+            ordersRootObject.Orders.Add(orderDto);
+
+            var json = JsonFieldsSerializer.Serialize(ordersRootObject,fields);
 
             return new RawJsonActionResult(json);
         }
@@ -459,7 +505,7 @@ namespace Nop.Plugin.Api.Controllers
 
                     var shippingOption = shippingOptions
                         .Find(so => !string.IsNullOrEmpty(so.Name) && so.Name.Equals(shippingOptionName, StringComparison.InvariantCultureIgnoreCase));
-                    
+
                     _genericAttributeService.SaveAttribute(customer,
                         NopCustomerDefaults.SelectedShippingOptionAttribute,
                         shippingOption, storeId);
@@ -527,11 +573,22 @@ namespace Nop.Plugin.Api.Controllers
 
         private PlaceOrderResult PlaceOrder(Order newOrder, Customer customer)
         {
+            int cardExpirationMonth = 0;
+            int cardExpirationYear = 0;
+            int.TryParse(newOrder.CardExpirationMonth, out cardExpirationMonth);
+            int.TryParse(newOrder.CardExpirationYear, out cardExpirationYear);
+
             var processPaymentRequest = new ProcessPaymentRequest
             {
                 StoreId = newOrder.StoreId,
                 CustomerId = customer.Id,
-                PaymentMethodSystemName = newOrder.PaymentMethodSystemName
+                PaymentMethodSystemName = newOrder.PaymentMethodSystemName,
+                CreditCardName = newOrder.CardName,
+                CreditCardNumber = newOrder.CardNumber,
+                CreditCardType = newOrder.CardType,
+                CreditCardExpireMonth = cardExpirationMonth,
+                CreditCardExpireYear = cardExpirationYear,
+                CreditCardCvv2 = newOrder.CardCvv2,
             };
 
 
@@ -573,12 +630,36 @@ namespace Nop.Plugin.Api.Controllers
                         orderItem.RentalEndDateUtc = null;
                     }
 
-                    var attributesXml = _productAttributeConverter.ConvertToXml(orderItem.Attributes.ToList(), product.Id);                
+                    var existingItem = _shoppingCartService.FindShoppingCartItemInTheCart(
+                                                                                    customer.ShoppingCartItems.ToList(),
+                                                                                    ShoppingCartType.ShoppingCart,
+                                                                                    product,
+                                                                                    orderItem.AttributesXml,
+                                                                                    orderItem.UnitPriceExclTax.HasValue ? orderItem.UnitPriceExclTax.Value : 0M,
+                                                                                    orderItem.RentalStartDateUtc,
+                                                                                    orderItem.RentalEndDateUtc);
 
-                    var errors = _shoppingCartService.AddToCart(customer, product,
-                        ShoppingCartType.ShoppingCart, storeId,attributesXml,
-                        0M, orderItem.RentalStartDateUtc, orderItem.RentalEndDateUtc,
-                        orderItem.Quantity ?? 1);
+                    var errors = new List<string>();
+
+                    if (existingItem != null && orderItem.Quantity.HasValue && existingItem.Quantity != orderItem.Quantity)
+                    {
+                        existingItem.Quantity = orderItem.Quantity.Value;
+
+                        errors.AddRange(_shoppingCartService.UpdateShoppingCartItem(
+                            customer,
+                            existingItem.Id,
+                            existingItem.AttributesXml,
+                            existingItem.CustomerEnteredPrice,
+                            existingItem.RentalStartDateUtc,
+                            existingItem.RentalEndDateUtc));
+                    }
+                    else
+                    {
+                        errors.AddRange(_shoppingCartService.AddToCart(customer, product,
+                            ShoppingCartType.ShoppingCart, storeId, orderItem.AttributesXml,
+                            0M, orderItem.RentalStartDateUtc, orderItem.RentalEndDateUtc,
+                            orderItem.Quantity ?? 1));
+                    }
 
                     if (errors.Count > 0)
                     {
@@ -594,5 +675,5 @@ namespace Nop.Plugin.Api.Controllers
 
             return shouldReturnError;
         }
-     }
+    }
 }

--- a/Nop.Plugin.Api/Controllers/ProductsController.cs
+++ b/Nop.Plugin.Api/Controllers/ProductsController.cs
@@ -96,8 +96,8 @@ namespace Nop.Plugin.Api.Controllers
                 return Error(HttpStatusCode.BadRequest, "page", "invalid page parameter");
             }
 
-            var allProducts = _productApiService.GetProducts(parameters.Ids, parameters.CreatedAtMin, parameters.CreatedAtMax, parameters.UpdatedAtMin,
-                                                                        parameters.UpdatedAtMax, parameters.Limit, parameters.Page, parameters.SinceId, parameters.CategoryId,
+            var allProducts = _productApiService.GetProducts(parameters.Ids, parameters.Skus, parameters.CreatedAtMin, parameters.CreatedAtMax, parameters.UpdatedAtMin,
+                                                                        parameters.UpdatedAtMax, parameters.Limit, parameters.Page, parameters.SinceId, parameters.CategoryId, parameters.IncludeChildren,
                                                                         parameters.VendorName, parameters.PublishedStatus)
                                                 .Where(p => StoreMappingService.Authorize(p));
             

--- a/Nop.Plugin.Api/Converters/ApiTypeConverter.cs
+++ b/Nop.Plugin.Api/Converters/ApiTypeConverter.cs
@@ -88,6 +88,16 @@ namespace Nop.Plugin.Api.Converters
             return null;
         }
 
+        public IList<string> ToListOfStrings(string value)
+        {
+            if (string.IsNullOrEmpty(value))
+            {
+                return null;
+            }
+
+            return value.Split(",").ToList(); //TODO:  this will break if we have commas in the strings
+        }
+
         public bool? ToStatus(string value)
         {
             if (!string.IsNullOrEmpty(value))

--- a/Nop.Plugin.Api/Converters/IApiTypeConverter.cs
+++ b/Nop.Plugin.Api/Converters/IApiTypeConverter.cs
@@ -9,6 +9,7 @@ namespace Nop.Plugin.Api.Converters
         int ToInt(string value);
         int? ToIntNullable(string value);
         IList<int> ToListOfInts(string value);
+        IList<string> ToListOfStrings(string value);
         bool? ToStatus(string value);
         object ToEnumNullable(string value, Type type);
     }

--- a/Nop.Plugin.Api/Converters/ObjectConverter.cs
+++ b/Nop.Plugin.Api/Converters/ObjectConverter.cs
@@ -55,6 +55,10 @@ namespace Nop.Plugin.Api.Converters
             {
                 return _apiTypeConverter.ToListOfInts(value);
             }
+            else if (type == typeof(List<string>))
+            {
+                return _apiTypeConverter.ToListOfStrings(value);
+            }
             else if(type == typeof(bool?))
             {
                 // Because currently status is the only boolean and we need to accept published and unpublished statuses.

--- a/Nop.Plugin.Api/DTOs/Customers/BaseCustomerDto.cs
+++ b/Nop.Plugin.Api/DTOs/Customers/BaseCustomerDto.cs
@@ -9,6 +9,9 @@ namespace Nop.Plugin.Api.DTOs.Customers
     {
         private List<int> _roleIds;
 
+        [JsonProperty("customer_guid")]
+        public Guid CustomerGuid { get; set; }
+
         [JsonProperty("username")]
         public string Username { get; set; }
         /// <summary>

--- a/Nop.Plugin.Api/DTOs/Orders/OrderDto.cs
+++ b/Nop.Plugin.Api/DTOs/Orders/OrderDto.cs
@@ -295,5 +295,28 @@ namespace Nop.Plugin.Api.DTOs.Orders
         /// </summary>
         [JsonProperty("customer_tax_display_type")]
         public string CustomerTaxDisplayType { get; set; }
+
+        
+        [JsonProperty("card_type")]
+        public string CardType { get; set; }
+
+        [JsonProperty("card_name")]
+        public string CardName { get; set; }
+
+        [JsonProperty("card_number")]
+        public string CardNumber { get; set; }
+
+        [JsonProperty("card_cvv2")]
+        public string CardCvv2 { get; set; }
+
+        [JsonProperty("card_expritation_month")]
+        public string CardExpirationMonth { get; set; }
+
+        [JsonProperty("card_expiration_year")]
+        public string CardExpirationYear { get; set; }
+
+        [JsonProperty("order_guid")]
+        public string OrderGuid { get; set; }
+
     }
 }

--- a/Nop.Plugin.Api/Models/ProductsParameters/ProductsParametersModel.cs
+++ b/Nop.Plugin.Api/Models/ProductsParameters/ProductsParametersModel.cs
@@ -27,6 +27,18 @@ namespace Nop.Plugin.Api.Models.ProductsParameters
         public List<int> Ids { get; set; }
 
         /// <summary>
+        /// A list of SKUs
+        /// </summary>
+        [JsonProperty("skus")]
+        public List<string> Skus { get; set; }
+
+        /// <summary>
+        /// A list of SKUs
+        /// </summary>
+        [JsonProperty("include_children")]
+        public bool IncludeChildren { get; set; }
+
+        /// <summary>
         /// Amount of results (default: 50) (maximum: 250)
         /// </summary>
         [JsonProperty("limit")]

--- a/Nop.Plugin.Api/Services/IOrderApiService.cs
+++ b/Nop.Plugin.Api/Services/IOrderApiService.cs
@@ -21,5 +21,6 @@ namespace Nop.Plugin.Api.Services
         int GetOrdersCount(DateTime? createdAtMin = null, DateTime? createdAtMax = null, OrderStatus? status = null,
                            PaymentStatus? paymentStatus = null, ShippingStatus? shippingStatus = null,
                            int? customerId = null, int? storeId = null);
+        Order GetOrderByOrderGuid(string orderGuid);
     }
 }

--- a/Nop.Plugin.Api/Services/IProductApiService.cs
+++ b/Nop.Plugin.Api/Services/IProductApiService.cs
@@ -8,9 +8,10 @@ namespace Nop.Plugin.Api.Services
     public interface IProductApiService
     {
         IList<Product> GetProducts(IList<int> ids = null,
+            IList<string> skus = null,
             DateTime? createdAtMin = null, DateTime? createdAtMax = null, DateTime? updatedAtMin = null, DateTime? updatedAtMax = null,
            int limit = Configurations.DefaultLimit, int page = Configurations.DefaultPageValue, int sinceId = Configurations.DefaultSinceId, 
-           int? categoryId = null, string vendorName = null, bool? publishedStatus = null);
+           int? categoryId = null, bool includeChildren = false, string vendorName = null, bool? publishedStatus = null);
 
         int GetProductsCount(DateTime? createdAtMin = null, DateTime? createdAtMax = null, 
             DateTime? updatedAtMin = null, DateTime? updatedAtMax = null, bool? publishedStatus = null, 

--- a/Nop.Plugin.Api/Services/OrderApiService.cs
+++ b/Nop.Plugin.Api/Services/OrderApiService.cs
@@ -124,5 +124,16 @@ namespace Nop.Plugin.Api.Services
 
             return query;
         }
+
+        public Order GetOrderByOrderGuid(string orderGuid)
+        {
+            Guid ordrGuid;
+            if (!string.IsNullOrWhiteSpace(orderGuid)
+                && (Guid.TryParse(orderGuid,out ordrGuid)))
+            {
+                return _orderRepository.Table.FirstOrDefault(order => order.OrderGuid == ordrGuid); 
+            }
+            return null;
+        }
     }
 }

--- a/Nop.Plugin.Api/Services/ProductApiService.cs
+++ b/Nop.Plugin.Api/Services/ProductApiService.cs
@@ -29,11 +29,12 @@ namespace Nop.Plugin.Api.Services
         }
 
         public IList<Product> GetProducts(IList<int> ids = null,
+            IList<string> skus = null,
             DateTime? createdAtMin = null, DateTime? createdAtMax = null, DateTime? updatedAtMin = null, DateTime? updatedAtMax = null,
-           int limit = Configurations.DefaultLimit, int page = Configurations.DefaultPageValue, int sinceId = Configurations.DefaultSinceId,
-           int? categoryId = null, string vendorName = null, bool? publishedStatus = null)
+            int limit = Configurations.DefaultLimit, int page = Configurations.DefaultPageValue, int sinceId = Configurations.DefaultSinceId,
+            int? categoryId = null, bool includeChildren = false, string vendorName = null, bool? publishedStatus = null)
         {
-            var query = GetProductsQuery(createdAtMin, createdAtMax, updatedAtMin, updatedAtMax, vendorName, publishedStatus, ids, categoryId);
+            var query = GetProductsQuery(createdAtMin, createdAtMax, updatedAtMin, updatedAtMax, vendorName, publishedStatus, ids, skus, categoryId, includeChildren);
 
             if (sinceId > 0)
             {
@@ -71,14 +72,18 @@ namespace Nop.Plugin.Api.Services
 
         private IQueryable<Product> GetProductsQuery(DateTime? createdAtMin = null, DateTime? createdAtMax = null, 
             DateTime? updatedAtMin = null, DateTime? updatedAtMax = null, string vendorName = null, 
-            bool? publishedStatus = null, IList<int> ids = null, int? categoryId = null)
-            
+            bool? publishedStatus = null, IList<int> ids = null, IList<string> skus = null, int? categoryId = null, bool includeChildren = false)
         {
             var query = _productRepository.Table;
 
             if (ids != null && ids.Count > 0)
             {
                 query = query.Where(c => ids.Contains(c.Id));
+            }
+
+            if (skus != null && skus.Count > 0)
+            {
+                query = query.Where(x => skus.Contains(x.Sku));
             }
 
             if (publishedStatus != null)
@@ -126,6 +131,15 @@ namespace Nop.Plugin.Api.Services
                 query = from product in query
                         join productCategoryMapping in categoryMappingsForProduct on product.Id equals productCategoryMapping.ProductId
                         select product;
+            }
+
+            if(includeChildren)
+            {
+                var childrenProducts = from childProduct in _productRepository.Table
+                                       join product in query on childProduct.ParentGroupedProductId equals product.Id
+                                       select childProduct;
+
+                query = query.Union(childrenProducts);
             }
 
             query = query.OrderBy(product => product.Id);


### PR DESCRIPTION
This PR adds two parameters to the product API calls:

- "Skus" allows querying products based on their sku field. 
- "IncludeChildren" allows getting a products and any children products (based on "ParentGroupedProductId" field)

There is an extra commit in this PR that relates to creating guest customers.  This was a mistake, and should not have made it into this branch.  That code was been removed in the last commit.

Additionally, this PR now also includes a bug for for #182 .